### PR TITLE
Remove a misbehaving CI rule

### DIFF
--- a/.circleci/rc.yaml
+++ b/.circleci/rc.yaml
@@ -26,7 +26,6 @@ plugins:
   - remark-lint-no-duplicate-headings
   - remark-lint-no-multiple-toplevel-headings
   - remark-lint-no-heading-punctuation
-  - remark-lint-no-emphasis-as-heading
   - - remark-lint-maximum-heading-length
     - 70
   - - remark-lint-heading-style


### PR DESCRIPTION
**Related Issue(s):** None


**Proposed Changes:**

The CI rule removed misbehaves a bit and is not so important. Removed in STAC spec so removed here too for consistency.

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [x] API only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-api-spec/blob/dev/README.md#openapi-definitions).