### PR TITLE
Fix broken link to ItemCollection spec

### DIFF
--- a/api-spec.md
+++ b/api-spec.md
@@ -103,7 +103,7 @@ See the [OpenAPI specification document](openapi/STAC.yaml).
 | Endpoint  | Returns                                                        | Description |
 | --------  | -------------------------------------------------------------- | ----------- |
 | `/`       | [Catalog](./stac-spec/catalog-spec/catalog-spec.md)            | Extends `/` from OAFeat to return a full STAC catalog. |
-| `/search` | [ItemCollection](./stac-spec/item-spec/itemcollection-spec.md) | Retrieves a group of Items matching the provided search predicates, probably containing search metadata from the `search` extension |
+| `/search` | [ItemCollection](./stac-spec/collection-spec/collection-spec.md) | Retrieves a group of Items matching the provided search predicates, probably containing search metadata from the `search` extension |
 
 The `/` endpoint should function as a complete `Catalog` representation of all the data contained in the API and linked 
 to in some way from root through `Collections` and `Items`.


### PR DESCRIPTION
**Related Issue(s):** N/A

**Proposed Changes:**

1. Fix broken link to ItemCollection spec.

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [ ] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] API only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-api-spec/blob/dev/README.md#openapi-definitions).