### PR TITLE
specify type of search Link, wordsmith other API text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For changes in 0.9.0 and prior, see the [STAC Spec Changelog](https://github.com
 
 ### Changed
 - Context Extension OpenAPI spec was updated to remove the no longer used `next` attribute
+- Added root endpoint Link `search` must have `type` of `application/geo+json`
 
 ### Fixed
 

--- a/api-spec.md
+++ b/api-spec.md
@@ -104,14 +104,19 @@ See the [OpenAPI specification document](openapi/STAC.yaml).
 | /search       | [ItemCollection](../item-spec/itemcollection-spec.md) | Retrieves a group of Items matching the 
 provided search predicates, probably containing search metadata from the `search` extension |
 
-The root endpoint (`/`) should function as a complete `Catalog` representation of all the data contained in the API. All `Collections` and `Items` should be linked to from the root through a `data` Link (returning all `Collections`), one or more `child` Links each referencing a single `Collection`, and a `search` Link referencing the `/search` endpoint.
+The root endpoint (`/`) is most useful when it presents a complete `Catalog` representation of all the data contained in the API, such that all `Collections` and `Items` can be navigated to by transitively traversing links from this root. This spec does not require any API endpoints from OAFeat or STAC API to be implemented, so these links may not exist if the endpoint has not been implemented.
+
+Links with these `rel` attributes should exist in the root endpoint if the reference API endpoint is implemented:
+* `data` with href to the OAFeat `/collections` endpoint
+* `child` (one or more) with href to a single `Collection` at the OAFeat `/collections/{collectionId}` endpoint
+* `search` with href to the `/search` endpoint (**required** if search endpoint is implemented)
 
 The `/search` endpoint is similar to the `/collections/{collectionId}/items` endpoint in OAFeat in that it 
 accepts parameters for filtering; however, it performs the filtering across all collections. The parameters accepted are 
 the same as the Filter Parameters above; however, the *[extensions](extensions/README.md)* also provide advanced querying 
 parameters.
 
-If the `/search` endpoint is implemented, it is recommended to add a Link to the root endpoint (`/`) with the `rel` type set to `search` that refers to the search endpoint in the `href` property, with a `type` of `application/geo+json`. This Link should look like:
+If the `/search` endpoint is implemented, it is **required** to add a Link to the root endpoint (`/`) with the `rel` type set to `search` that refers to the search endpoint in the `href` property, with a `type` of `application/geo+json`. This Link should look like:
 ```
 {
     "href": "https://example.com/search",

--- a/api-spec.md
+++ b/api-spec.md
@@ -104,12 +104,11 @@ See the [OpenAPI specification document](openapi/STAC.yaml).
 | /search       | [ItemCollection](../item-spec/itemcollection-spec.md) | Retrieves a group of Items matching the 
 provided search predicates, probably containing search metadata from the `search` extension |
 
-The `/` endpoint should function as a complete `Catalog` representation of all the data contained in the API and linked 
-to in some way from root to `Collections` and `Items` through `children` and `child` Links.
+The root endpoint (`/`) should function as a complete `Catalog` representation of all the data contained in the API. All `Collections` and `Items` should be linked to from the root through a `data` Link (returning all `Collections`), one or more `child` Links each referencing a single `Collection`, and a `search` Link referencing the `/search` endpoint.
 
-The `/search` endpoint is similar to the `/collections/{collectionId}/items` endpoint in OGC API - Features in that it 
-accepts parameters for filtering, however it performs the filtering across all collections. The parameters accepted are 
-the same as the Filter Parameters above, however the *[extensions](extensions/README.md)* also provide advanced querying 
+The `/search` endpoint is similar to the `/collections/{collectionId}/items` endpoint in OAFeat in that it 
+accepts parameters for filtering; however, it performs the filtering across all collections. The parameters accepted are 
+the same as the Filter Parameters above; however, the *[extensions](extensions/README.md)* also provide advanced querying 
 parameters.
 
 It is **required** to add to the root endpoint (`/`) object a Link in the `links` array with the `rel` type set to `search`  that refers to the search endpoint in the `href` property, with a `type` of `application/geo+json`. This Link should look like:

--- a/api-spec.md
+++ b/api-spec.md
@@ -92,10 +92,10 @@ The `/collections/{collection_id}/items` endpoint accepts parameters for filteri
 Items in the collection should match all filters to be returned when querying. This implies a logical AND operation. If 
 an OR operation is needed, it should be specified through an extension filter.
 
-## STAC Endpoints
+## STAC API Endpoints
 
-STAC provides some additional endpoints for the root Catalog itself, as well as the capability to search the Catalog. 
-Note that a STAC API does not need to implement OAFeat, in which case it would only support the endpoints given below. 
+STAC API provides additional attributes for the root Catalog endpoint and defines an endpoint to search the Catalog. 
+Note that a STAC API does not need to implement OAFeat, in which case it would support only the endpoints below. 
 See the [OpenAPI specification document](openapi/STAC.yaml).
 
 | Endpoint      | Returns | Description |
@@ -105,15 +105,22 @@ See the [OpenAPI specification document](openapi/STAC.yaml).
 provided search predicates, probably containing search metadata from the `search` extension |
 
 The `/` endpoint should function as a complete `Catalog` representation of all the data contained in the API and linked 
-to in some way from root through `Collections` and `Items`.
+to in some way from root to `Collections` and `Items` through `children` and `child` Links.
 
 The `/search` endpoint is similar to the `/collections/{collectionId}/items` endpoint in OGC API - Features in that it 
 accepts parameters for filtering, however it performs the filtering across all collections. The parameters accepted are 
 the same as the Filter Parameters above, however the *[extensions](extensions/README.md)* also provide advanced querying 
 parameters.
 
-If the `/search` endpoint is implemented, it is **required** to add a link with the `rel` type set to `search` to the 
-`links` array in `/` that refers to the search endpoint in the `href` property.
+It is **required** to add to the root endpoint (`/`) object a Link in the `links` array with the `rel` type set to `search`  that refers to the search endpoint in the `href` property, with a `type` of `application/geo+json`. This Link should look like:
+```
+{
+    "href": "https://example.com/search",
+    "rel": "search",
+    "title": "Search",
+    "type": "application/geo+json"
+}
+```
 
 ## Filter Parameters and Fields
 

--- a/api-spec.md
+++ b/api-spec.md
@@ -111,7 +111,7 @@ accepts parameters for filtering; however, it performs the filtering across all 
 the same as the Filter Parameters above; however, the *[extensions](extensions/README.md)* also provide advanced querying 
 parameters.
 
-It is **required** to add to the root endpoint (`/`) object a Link in the `links` array with the `rel` type set to `search`  that refers to the search endpoint in the `href` property, with a `type` of `application/geo+json`. This Link should look like:
+If the `/search` endpoint is implemented, it is recommended to add a Link to the root endpoint (`/`) with the `rel` type set to `search` that refers to the search endpoint in the `href` property, with a `type` of `application/geo+json`. This Link should look like:
 ```
 {
     "href": "https://example.com/search",


### PR DESCRIPTION
**Related Issue(s):** #

n/a

**Proposed Changes:**

1. require root link for search be `application/geo+json`, which matches the response type of the /search endpoint

**PR Checklist:**

- [X] This PR has **no** breaking changes.
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] n/a API only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-api-spec/blob/dev/README.md#openapi-definitions).