### PR TITLE
Fix collection description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For changes in 0.9.0 and prior, see the [STAC Spec Changelog](https://github.com
 ### Changed
 - Context Extension OpenAPI spec was updated to remove the no longer used `next` attribute
 - Added root endpoint Link `search` must have `type` of `application/geo+json`
+- Corrected the description of endpoint `/collections` to say it returns an object per OAFeat, instead of an array of Collection
 
 ### Fixed
 

--- a/api-spec.md
+++ b/api-spec.md
@@ -83,10 +83,12 @@ The core OGC API - Features endpoints are shown below, with details provided in 
 | ------------ | ------------- | ----------- |
 | /            | JSON          | Landing page, links to API capabilities |
 | /conformance | JSON          | Info about standards to which the API conforms |
-| /collections | [Collection]  | List of Collections contained in the catalog |
+| /collections | JSON          | List of Collections contained in the catalog |
 | /collections/{collectionId}  | Collection | Returns single Collection JSON |
 | /collections/{collectionId}/items | ItemCollection | GeoJSON FeatureCollection-conformant entity of Items in collection |
 | /collections/{collectionId}/items/{featureId} | Item | Returns single Item (GeoJSON Feature) |
+
+The `/collections` endpoint returns an object with a field `collections` that is an array of Collection objects.
 
 The `/collections/{collection_id}/items` endpoint accepts parameters for filtering the results (also called filters). 
 Items in the collection should match all filters to be returned when querying. This implies a logical AND operation. If 


### PR DESCRIPTION
**Related Issue(s):** #44

**Proposed Changes:**

1. Update api-spec.md Returns value to match that of OAFeat spec

I implemented this wrong about a year ago, and just realized that this is where I got that incorrect idea from. 

Also, https://earth-search.aws.element84.com/v0/collections implements this as a top-level array instead of the OAFeat defintion @matthewhanson 

**PR Checklist:**

- [X] This PR has **no** breaking changes.
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] n/a API only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-api-spec/blob/dev/README.md#openapi-definitions).