### PR TITLE
Bbox improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- BBOX openapi yaml to only allow 4 or 6 element arrays
 
 ## Older versions
 

--- a/STAC-extensions.yaml
+++ b/STAC-extensions.yaml
@@ -527,15 +527,13 @@ components:
       required: false
       schema:
         type: array
-        minItems: 4
-        maxItems: 6
-        items:
-          type: number
         oneOf:
           - minItems: 4
             maxItems: 4
           - minItems: 6
             maxItems: 6
+        items:
+          type: number
       style: form
       explode: false
     collectionId:

--- a/STAC-extensions.yaml
+++ b/STAC-extensions.yaml
@@ -531,6 +531,11 @@ components:
         maxItems: 6
         items:
           type: number
+        oneOf:
+          - minItems: 4
+            maxItems: 4
+          - minItems: 6
+            maxItems: 6
       style: form
       explode: false
     collectionId:

--- a/STAC.yaml
+++ b/STAC.yaml
@@ -283,15 +283,13 @@ components:
       required: false
       schema:
         type: array
-        minItems: 4
-        maxItems: 6
-        items:
-          type: number
         oneOf:
           - minItems: 4
             maxItems: 4
           - minItems: 6
             maxItems: 6
+        items:
+          type: number
       style: form
       explode: false
     collectionId:

--- a/STAC.yaml
+++ b/STAC.yaml
@@ -287,6 +287,11 @@ components:
         maxItems: 6
         items:
           type: number
+        oneOf:
+          - minItems: 4
+            maxItems: 4
+          - minItems: 6
+            maxItems: 6
       style: form
       explode: false
     collectionId:

--- a/api-spec.md
+++ b/api-spec.md
@@ -210,7 +210,6 @@ GET /search?collections=landsat8,sentinel&bbox=-10.415,36.066,3.779,44.213&limit
 }
 ```
 
-
 | Parameter    | Type             | APIs         | Description |
 | -----------  | ---------------- | ------------ | ----------- |
 | collectionId | string           | OAFeat       | **Path-only** Single Collection ID to include in the search for items. Only Items in one of the provided Collection will be searched |

--- a/api-spec.md
+++ b/api-spec.md
@@ -7,7 +7,7 @@ OGC Web Feature Service (WFS). Future STAC API releases will align with
 
 The OGC API - Features is a standard API that represents collections of geospatial data. It defines the RESTful interface 
 to query geospatial data, with GeoJSON as a main return type. With OAFeat you can return any `Feature`, which is a geometry 
-plus any number of properties. The core [STAC Item spec](./stac-spec/item-spec/README.md) 
+plus any number of properties. The core [STAC Item spec](https://github.com/radiantearth/stac-spec/item-spec/README.md) 
 enhances the core `Feature` with additional requirements and options to enable cataloging of spatiotemporal 'assets' like 
 satellite imagery. This STAC `Item` always links to an asset, and these assets always have a capture time, so it requires 
 fields for `datetime` and `assets`. The STAC API extends the OAFeat core with some key functionality to enable search of 
@@ -16,14 +16,14 @@ geospatial assets, detailed below.
 OAFeat also defines the concept of a Collection, which contains Features. In OAFeat Collections are the sets of data that can 
 be queried ([7.11](http://docs.opengeospatial.org/is/17-069r3/17-069r3.html#_collections_)), and each describes basic 
 information about the geospatial dataset, like its name and description, as well as the spatial and temporal extents of all 
-the data contained. [STAC collections](./stac-spec/collection-spec/README.md) contain this same 
+the data contained. [STAC collections](https://github.com/radiantearth/stac-spec/collection-spec/README.md) contain this same 
 information, along with other STAC specific fields to provide additional metadata for searching spatiotemporal assets, and 
 thus are compliant with both OAFeat Collections and STAC Collections and are returned from the `/collections/{collection_id}` 
 endpoint.
 
 In OAFeat Features are the individual records within a Collection and are provided in GeoJSON format. 
-[STAC Items](./stac-spec/item-spec/README.md) are analogous to OAFeat Features, are in GeoJSON, and are returned from the 
-`/collections/{collection_id}/items/{item_id}` endpoint.
+[STAC Items](https://github.com/radiantearth/stac-spec/item-spec/README.md) are analogous to OAFeat Features, 
+are in GeoJSON, and are returned from the `/collections/{collection_id}/items/{item_id}` endpoint.
 
 A typical OAFeat will have multiple collections, and each will just offer simple search for its particular collection at 
 `GET /collections/{collectionId}/items`.
@@ -104,8 +104,8 @@ See the [OpenAPI specification document](openapi/STAC.yaml).
 
 | Endpoint  | Returns                                                        | Description |
 | --------  | -------------------------------------------------------------- | ----------- |
-| `/`       | [Catalog](./stac-spec/catalog-spec/catalog-spec.md)            | Extends `/` from OAFeat to return a full STAC catalog. |
-| `/search` | [ItemCollection](./stac-spec/item-spec/itemcollection-spec.md) | Retrieves a group of Items matching the provided search predicates, probably containing search metadata from the `search` extension |
+| `/`       | [Catalog](https://github.com/radiantearth/stac-spec/catalog-spec/catalog-spec.md)            | Extends `/` from OAFeat to return a full STAC catalog. |
+| `/search` | [ItemCollection](https://github.com/radiantearth/stac-spec/item-spec/itemcollection-spec.md) | Retrieves a group of Items matching the provided search predicates, probably containing search metadata from the `search` extension |
 
 The root endpoint (`/`) is most useful when it presents a complete `Catalog` representation of all the data contained in the API, such that all `Collections` and `Items` can be navigated to by transitively traversing links from this root. This spec does not require any API endpoints from OAFeat or STAC API to be implemented, so these links may not exist if the endpoint has not been implemented.
 
@@ -135,7 +135,7 @@ This Link should look like:
 
 Unless otherwise noted by **Path-only**, these filters are passed as query string parameters, form parameters, or JSON 
 entity fields.  For filters that represent a set of values, query and form parameters should use comma-separated 
-string values and JSON entity attributes should use JSON Arrays. 
+string values (with no outer brackets \[ or \]) and JSON entity attributes should use JSON Arrays. 
 
 | Parameter    | Type             | APIs         | Description |
 | -----------  | ---------------- | ------------ | ----------- |
@@ -148,7 +148,7 @@ string values and JSON entity attributes should use JSON Arrays.
 | collections  | \[string]        | STAC         | Array of Collection IDs to include in the search for items. Only Items in one of the provided Collections will be searched |
 
 Only one of either **intersects** or **bbox** should be specified.  If both are specified, a 400 Bad Request response 
-should be returned. 
+should be returned. See [examples](examples.md) to see sample requests.
 
 ## Reserved Parameters
 

--- a/api-spec.md
+++ b/api-spec.md
@@ -185,11 +185,31 @@ to get to the next page without mirroring the entire query structure back to the
 
 Example requests can be found in the [examples document](./examples.md#paging).
 
-## Filter Parameters and Fields
+## Query Parameters and Fields
 
-Unless otherwise noted by **Path-only**, these filters are passed as query string parameters, form parameters, or JSON 
-entity fields.  For filters that represent a set of values, query and form parameters should use comma-separated 
-string values (with no outer brackets \[ or \]) and JSON entity attributes should use JSON Arrays. 
+The following list of parameters is used to narrow search queries. Most all of them can be represented as
+query string parameters in a GET request, or as JSON entity fields in a POST request. One parameter,
+`collectionId` is designated as **Path-only**, which means it should only be used as a query string parameter.
+The `collections` parameter works similarly, but takes multiple collectionId's in an array, so it can be used
+with a single value array in JSON if the same functionality is desired. For filters that represent a set of values, 
+query parameters should use comma-separated string values (with no outer brackets \[ or \]) and JSON entity 
+attributes should use JSON Arrays. 
+
+#### Examples
+
+```http
+GET /search?collections=landsat8,sentinel&bbox=-10.415,36.066,3.779,44.213&limit=200&datetime=2017-05-05T00:00:00Z
+```
+
+```json
+{
+    "collections": ["landsat8","sentinel"],
+    "bbox": [10.415,36.066,3.779,44.213],
+    "limit": 200,
+    "datetime": "2017-05-05T00:00:00Z"
+}
+```
+
 
 | Parameter    | Type             | APIs         | Description |
 | -----------  | ---------------- | ------------ | ----------- |

--- a/api-spec.md
+++ b/api-spec.md
@@ -195,7 +195,7 @@ with a single value array in JSON if the same functionality is desired. For filt
 query parameters should use comma-separated string values (with no outer brackets \[ or \]) and JSON entity 
 attributes should use JSON Arrays. 
 
-#### Examples
+### Examples
 
 ```http
 GET /search?collections=landsat8,sentinel&bbox=-10.415,36.066,3.779,44.213&limit=200&datetime=2017-05-05T00:00:00Z

--- a/openapi/OAFeat.yaml
+++ b/openapi/OAFeat.yaml
@@ -152,8 +152,11 @@ components:
       required: false
       schema:
         type: array
-        minItems: 4
-        maxItems: 6
+        oneOf:
+        - minItems: 4
+          maxItems: 4
+        - minItems: 6
+          maxItems: 6
         items:
           type: number
       style: form

--- a/openapi/OAFeat.yaml
+++ b/openapi/OAFeat.yaml
@@ -153,10 +153,10 @@ components:
       schema:
         type: array
         oneOf:
-        - minItems: 4
-          maxItems: 4
-        - minItems: 6
-          maxItems: 6
+          - minItems: 4
+            maxItems: 4
+          - minItems: 6
+            maxItems: 6
         items:
           type: number
       style: form

--- a/openapi/STAC.yaml
+++ b/openapi/STAC.yaml
@@ -137,8 +137,6 @@ components:
       explode: false
     # This schema extends OAFeat.yaml#/parameters/bbox.
     bbox:
-      name: bbox
-      in: query
       description: |-
         Only features that have a geometry that intersects the bounding box are selected.
         The bounding box is provided as four or six numbers, depending on
@@ -174,18 +172,6 @@ components:
         WGS 84 (from 160.6°E to 170°W and from 55.95°S to 25.89°S) would be
         represented in JSON as `[160.6, -55.95, -170, -25.89]` and in a query as
         `bbox=160.6,-55.95,-170,-25.89`.
-      required: false
-      schema:
-        type: array
-        oneOf:
-          - minItems: 4
-            maxItems: 4
-          - minItems: 6
-            maxItems: 6 
-        items:
-          type: number
-      style: form
-      explode: false
   responses:
     # This schema extends OAFeat.yaml#/components/responses/LandingPage.
     LandingPage:

--- a/openapi/STAC.yaml
+++ b/openapi/STAC.yaml
@@ -177,8 +177,11 @@ components:
       required: false
       schema:
         type: array
-        minItems: 4
-        maxItems: 6
+        oneOf:
+          - minItems: 4
+            maxItems: 4
+          - minItems: 6
+            maxItems: 6 
         items:
           type: number
       style: form


### PR DESCRIPTION
**Related Issue(s):** #28 #47 


**Proposed Changes:**

1. Update the openapi yaml to only allow 4 or 6 element bbox arrays
2. Link to examples and put in a bit more language around bbox

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [x] API only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-api-spec/blob/dev/README.md#openapi-definitions).