### PR TITLE
Set stac-spec to 1.0.0-beta.2 #55

### DIFF
--- a/.remarkignore
+++ b/.remarkignore
@@ -1,2 +1,0 @@
-/CHANGELOG.md
-/stac-spec/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## \[Unreleased\]
 
 ### Added
 
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Older versions
 
-See the [stac-spec CHANGELOG](https://github.com/radiantearth/stac-spec/blob/v0.9.0/CHANGELOG.md) for STAC API releases prior to or equal to version 0.9.0.
+See the [stac-spec CHANGELOG](https://github.com/radiantearth/stac-spec/blob/v0.9.0/CHANGELOG.md)
+for STAC API releases prior to or equal to version 0.9.0.
 
-
-[Unreleased]: <https://github.com/radiantearth/stac-api-spec/compare/master...dev>
+\[Unreleased\]: <https://github.com/radiantearth/stac-api-spec/compare/master...dev>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Updated to STAC specification version 1.0.0-beta.2
 - Context Extension OpenAPI spec was updated to remove the no longer used `next` attribute
 - Added root endpoint Link `search` must have `type` of `application/geo+json`
 - Corrected the description of endpoint `/collections` to say it returns an object per OAFeat, instead of an array of Collection

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ time. The core STAC specification lives at [gitub.com/radiantearth/stac-spec](ht
 
 A STAC API is the dynamic version of a SpatioTemporal Asset Catalog. It returns a STAC [Catalog](https://github.com/radiantearth/stac-spec/catalog-spec/catalog-spec.md), 
 [Collection](https://github.com/radiantearth/stac-spec/collection-spec/collection-spec.md), [Item](https://github.com/radiantearth/stac-spec/item-spec/item-spec.md), 
-or [ItemCollection](https://github.com/radiantearth/stac-spec/item-spec/itemcollection-spec.md), depending on the endpoint.
+or ItemCollection, depending on the endpoint.
 Catalogs and Collections are JSON, while Items and ItemCollections are GeoJSON-compliant entities with foreign members.  
 Typically, a Feature is used when returning a single Item, and FeatureCollection when multiple Items (rather than a JSON array of Item entities).
 

--- a/api-spec.md
+++ b/api-spec.md
@@ -105,7 +105,7 @@ See the [OpenAPI specification document](openapi/STAC.yaml).
 | Endpoint  | Returns                                                        | Description |
 | --------  | -------------------------------------------------------------- | ----------- |
 | `/`       | [Catalog](https://github.com/radiantearth/stac-spec/catalog-spec/catalog-spec.md)            | Extends `/` from OAFeat to return a full STAC catalog. |
-| `/search` | [ItemCollection](https://github.com/radiantearth/stac-spec/item-spec/itemcollection-spec.md) | Retrieves a group of Items matching the provided search predicates, probably containing search metadata from the `search` extension |
+| `/search` | ItemCollection | Retrieves a group of Items matching the provided search predicates, probably containing search metadata from the `search` extension |
 
 The root endpoint (`/`) is most useful when it presents a complete `Catalog` representation of all the data contained in the API, such that all `Collections` and `Items` can be navigated to by transitively traversing links from this root. This spec does not require any API endpoints from OAFeat or STAC API to be implemented, so these links may not exist if the endpoint has not been implemented.
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -36,7 +36,7 @@ stable for over a year and are used in twenty or more implementations.
 | ------------------------------------------------------ | -------------- | ----------- | -------- |
 | [Fields](fields/README.md)                             | *None*         | Adds parameter to control which fields are returned in the response. | *Pilot* |
 | [Query](query/README.md)                               | *None*         | Adds parameter to search Item and Collection properties. | *Pilot* |
-| [Context](context/README.md)                           | ItemCollection | Adds search related metadata (context) to [ItemCollection](../stac-spec/item-spec/itemcollection-spec.md). | *Proposal* |
+| [Context](context/README.md)                           | ItemCollection | Adds search related metadata (context) to ItemCollection. | *Proposal* |
 | [Sort](sort/README.md)                                 | *None*         | Adds Parameter to control sorting of returns results. | *Pilot* |
 | [Transaction](transaction/README.md)                   | *None*         | Adds PUT and DELETE endpoints for the creation, editing, and deleting of items and Collections. | *Pilot* |
 | [Items and Collections API Version](version/README.md) | *None*         | Adds GET versions resource to collections and items endpoints and provides semantics for a versioning scheme for collections and items. | *Proposal* |

--- a/extensions/context/README.md
+++ b/extensions/context/README.md
@@ -2,7 +2,7 @@
 
 **Extension [Maturity Classification](../README.md#extension-maturity): Proposal**
 
-This extension is intended to augment the core [ItemCollection](../../stac-spec/item-spec/itemcollection-spec.md)
+This extension is intended to augment the core ItemCollection
 object when the ItemCollection is the result of a search, for example, from calling the `/search` API endpoint.
 
 - [Example](examples/example.json)
@@ -12,7 +12,7 @@ object when the ItemCollection is the result of a search, for example, from call
 
 | Element   | Type                              | Description |
 | --------- | --------------------------------- | ----------- |
-| `context` | [Context Object](#context-object) | **REQUIRED.** The search-related metadata for the [ItemCollection](../../stac-spec/item-spec/itemcollection-spec.md). |
+| `context` | [Context Object](#context-object) | **REQUIRED.** The search-related metadata for the ItemCollection. |
 
 ## Context Object
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "serve-ext": "npm run generate-all && redoc-cli serve STAC-extensions.yaml --watch --options.expandResponses \"200,201,202,203,204\" --options.pathInMiddlePanel true",
     "serve": "npm run generate-all && redoc-cli serve STAC.yaml --watch --options.expandResponses \"200,201,202,203,204\" --options.pathInMiddlePanel true",
     "check": "npm run check-markdown && npm run check-openapi",
-    "check-markdown": "remark . -f -r .circleci/rc.yaml",
+    "check-markdown": "remark . -f -r .circleci/rc.yaml --no-ignore --ignore-pattern stac-spec/",
     "check-openapi": "npm run generate-all && spectral lint STAC.yaml && spectral lint STAC-extensions.yaml"
   },
   "dependencies": {


### PR DESCRIPTION
**Related Issue(s):** #55


**Proposed Changes:**

1. Set STAC Spec version from 0.9.0 to 1.0.0-beta.2

**PR Checklist:**

- [ ] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [ ] This PR has **no** breaking changes.
- [ ] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [ ] API only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-api-spec/blob/dev/README.md#openapi-definitions).