### PR TITLE
Remove bbox-crs for now

### DIFF
--- a/STAC-extensions.yaml
+++ b/STAC-extensions.yaml
@@ -514,11 +514,7 @@ components:
 
         The coordinate reference system of the values is WGS 84
 
-        longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84) unless
-
-        a different coordinate reference system is specified in the parameter
-
-        `bbox-crs`.
+        longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
 
 
         For WGS 84 longitude/latitude the values are in most cases the sequence

--- a/STAC.yaml
+++ b/STAC.yaml
@@ -262,11 +262,7 @@ components:
 
         The coordinate reference system of the values is WGS 84
 
-        longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84) unless
-
-        a different coordinate reference system is specified in the parameter
-
-        `bbox-crs`.
+        longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
 
 
         For WGS 84 longitude/latitude the values are in most cases the sequence

--- a/openapi/OAFeat.yaml
+++ b/openapi/OAFeat.yaml
@@ -154,8 +154,7 @@ components:
         * Maximum value, coordinate axis 3 (optional)
 
         The coordinate reference system of the values is WGS 84 longitude/latitude
-        (http://www.opengis.net/def/crs/OGC/1.3/CRS84) unless a different coordinate
-        reference system is specified in the parameter `bbox-crs`.
+        (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
 
         For WGS 84 longitude/latitude the values are in most cases the sequence of
         minimum longitude, minimum latitude, maximum longitude and maximum latitude.

--- a/openapi/STAC.yaml
+++ b/openapi/STAC.yaml
@@ -160,9 +160,7 @@ components:
         * Maximum value, coordinate axis 3 (optional)
 
         The coordinate reference system of the values is WGS 84
-        longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84) unless
-        a different coordinate reference system is specified in the parameter
-        `bbox-crs`.
+        longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84).
 
         For WGS 84 longitude/latitude the values are in most cases the sequence
         of minimum longitude, minimum latitude, maximum longitude and maximum


### PR DESCRIPTION
**Related Issue(s):** https://github.com/opengeospatial/ogcapi-features/issues/454


**Proposed Changes:**

1. Remove bbox-crs for now, it's only defined in the Features CRS extension and seems to confuse users.

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [ ] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
- [x] OpenAPI files only: I have run `npm run generate-all` to update the [generated OpenAPI files](https://github.com/radiantearth/stac-api-spec/blob/dev/README.md#openapi-definitions).
