### PR TITLE
Add description field to context object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!--lint disable no-duplicate-headings-->
+
 # Changelog
 All notable changes to this project will be documented in this file.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- The [context extension](./fragments/context/README.md) gained a nullable `description` field from the former Single File STAC extension
+
 ### Changed
 - The first extent in a Collection is always the overall extent, followed by more specific extents. [opengeospatial/ogcapi-features#520](https://github.com/opengeospatial/ogcapi-features/pull/520)
 

--- a/fragments/context/README.md
+++ b/fragments/context/README.md
@@ -29,7 +29,8 @@ implementing OGC API - Features.*
 | -------- | --------------- | ----------- |
 | returned | integer         | **REQUIRED** The count of results returned by this response. Equal to the cardinality of features array. |
 | limit    | integer \| null | The maximum number of results to which the result was limited. |
-| matched  | integer         | The count of total number of results that match for this query, possibly estimated, particularly in the context of NoSQL data stores. |
+| matched  | integer         | The count of total number of results that match for this query, possibly estimated. |
+| description | string \| null | A text description of these search results. |
 
 The default sort of query results should be stable, but may not be depending on the data store's sorting performance.
 It is recommended that the [Sort API Extension](../sort/README.md) be implemented in conjunction with this extension
@@ -48,7 +49,8 @@ if no parameter was provided, or the maximum limit used by the service implement
   "context": {
     "returned": 9,
     "limit": 10, 
-    "matched": 1092873
+    "matched": 9,
+    "description": "My awesome search results"
   }
 }
 ```

--- a/fragments/context/openapi.yaml
+++ b/fragments/context/openapi.yaml
@@ -32,3 +32,6 @@ components:
               type: integer
               minimum: 0
               example: 314159
+            description:
+              type: string
+              nullable: true


### PR DESCRIPTION
**Related Issue(s):** radiantearth/stac-spec#971

**Proposed Changes:**

1. Add a nullable `description` field to the context extension

The `single-file-stac` extension created collection-ish entities that are incompatible with the change to add a `type` field because they had a `type: FeatureCollection` requirement. Since they were identical to `ItemCollections` with the exception of a `description` field, this PR adds the nullable `description` field to the context extension.

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
