### PR TITLE
Clarification on multiple bounding boxes in an extent

### DIFF
--- a/.circleci/rc.yaml
+++ b/.circleci/rc.yaml
@@ -21,15 +21,14 @@ plugins:
     - 'fenced'
 # Headings
   - remark-lint-heading-increment
-  - remark-lint-no-duplicate-headings
   - remark-lint-no-multiple-toplevel-headings
   - remark-lint-no-heading-punctuation
-  - - remark-lint-no-shortcut-reference-link
-    - false
   - - remark-lint-maximum-heading-length
     - 70
   - - remark-lint-heading-style
     - atx
+  - - remark-lint-no-shortcut-reference-link
+    - false
 # Lists
   - remark-lint-list-item-bullet-indent
   - remark-lint-ordered-list-marker-style

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- The first extent in a Collection is always the overall extent, followed by more specific extents. [opengeospatial/ogcapi-features#520](https://github.com/opengeospatial/ogcapi-features/pull/520)
+
 ## [v1.0.0-beta.1] - 2020-12-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!--lint disable no-html-->
 <img src="https://github.com/radiantearth/stac-site/raw/master/images/logo/stac-030-long.png" alt="stac-logo" width="700"/>
 
 # STAC API

--- a/core/commons.yaml
+++ b/core/commons.yaml
@@ -247,9 +247,9 @@ components:
         extents are specified. Extensions may add additional members to represent other
         extents, for example, thermal or pressure ranges.
 
-        The first items in the arrays always describe the overall extent of
-        the data. All subsequent extents can be used to provide a more precise
-        description of the extent and identify clusters of data.
+        The first item in the array describes the overall extent of
+        the data. All subsequent items describe more precise extents, 
+        e.g., to identify clusters of data.
         Clients only interested in the overall extent will only need to
         access the first item in each array.
       required:
@@ -267,10 +267,9 @@ components:
               description: |-
                 One or more bounding boxes that describe the spatial extent of the dataset.
                 
-                The first bounding box always describes the overall spatial
-                extent of the data. All subsequent bounding boxes can be
-                used to provide a more precise description of the extent and
-                identify clusters of data.
+                The first bounding box describes the overall spatial
+                extent of the data. All subsequent bounding boxes describe 
+                more precise bounding boxes, e.g., to identify clusters of data.
                 Clients only interested in the overall spatial extent will
                 only need to access the first item in each array.
               type: array
@@ -335,10 +334,9 @@ components:
               description: |-
                 One or more time intervals that describe the temporal extent of the dataset.
 
-                The first time interval always describes the overall
-                temporal extent of the data. All subsequent time intervals
-                can be used to provide a more precise description of the
-                extent and identify clusters of data.
+                The first time interval describes the overall
+                temporal extent of the data. All subsequent time intervals describe 
+                more precise time intervals, e.g., to identify clusters of data.
                 Clients only interested in the overall extent will only need
                 to access the first item in each array.
               type: array

--- a/core/commons.yaml
+++ b/core/commons.yaml
@@ -246,6 +246,12 @@ components:
         The extent of the features in the collection. In the Core only spatial and temporal
         extents are specified. Extensions may add additional members to represent other
         extents, for example, thermal or pressure ranges.
+
+        The first items in the arrays always describe the overall extent of
+        the data. All subsequent extents can be used to provide a more precise
+        description of the extent and identify clusters of data.
+        Clients only interested in the overall extent will only need to
+        access the first item in each array.
       required:
         - spatial
         - temporal
@@ -260,9 +266,13 @@ components:
             bbox:
               description: |-
                 One or more bounding boxes that describe the spatial extent of the dataset.
-                In the Core only a single bounding box is supported. Extensions may support
-                additional areas. If multiple areas are provided, the union of the bounding
-                boxes describes the spatial extent.
+                
+                The first bounding box always describes the overall spatial
+                extent of the data. All subsequent bounding boxes can be
+                used to provide a more precise description of the extent and
+                identify clusters of data.
+                Clients only interested in the overall spatial extent will
+                only need to access the first item in each array.
               type: array
               minItems: 1
               items:
@@ -324,10 +334,13 @@ components:
             interval:
               description: |-
                 One or more time intervals that describe the temporal extent of the dataset.
-                The value `null` is supported and indicates an open time intervall.
-                In the Core only a single time interval is supported. Extensions may support
-                multiple intervals. If multiple intervals are provided, the union of the
-                intervals describes the temporal extent.
+
+                The first time interval always describes the overall
+                temporal extent of the data. All subsequent time intervals
+                can be used to provide a more precise description of the
+                extent and identify clusters of data.
+                Clients only interested in the overall extent will only need
+                to access the first item in each array.
               type: array
               minItems: 1
               items:
@@ -335,6 +348,8 @@ components:
                   Begin and end times of the time interval. The timestamps
                   are in the coordinate reference system specified in `trs`. By default
                   this is the Gregorian calendar.
+
+                  The value `null` is supported and indicates an open time interval.
                 type: array
                 minItems: 2
                 maxItems: 2


### PR DESCRIPTION
**Related Issue(s):** 
- https://github.com/radiantearth/stac-spec/issues/1064
- https://github.com/opengeospatial/ogcapi-features/pull/520


**Proposed Changes:**

1. Adopt clarification by OGC API - Features on multiple extents in collections

cc @cportele

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
