### PR TITLE
Don't deactivate other search parameters when filtering with ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Passing the `ids` parameter to an item search does not deactivate other query parameters [#125](https://github.com/radiantearth/stac-api-spec/pull/125)
 - The first extent in a Collection is always the overall extent, followed by more specific extents. [opengeospatial/ogcapi-features#520](https://github.com/opengeospatial/ogcapi-features/pull/520)
 
 ## [v1.0.0-beta.1] - 2020-12-10

--- a/item-search/README.md
+++ b/item-search/README.md
@@ -63,7 +63,7 @@ The core parameters for STAC search are defined by OAFeat, and STAC adds a few p
 | bbox         | \[number]        | OAFeat       | Requested bounding box.  Represented using either 2D or 3D geometries. The length of the array must be 2*n where n is the number of dimensions. The array contains all axes of the southwesterly most extent followed by all axes of the northeasterly most extent specified in Longitude/Latitude or Longitude/Latitude/Elevation based on [WGS 84](http://www.opengis.net/def/crs/OGC/1.3/CRS84). When using 3D geometries, the elevation of the southwesterly most extent is the minimum elevation in meters and the elevation of the northeasterly most extent is the maximum. |
 | datetime     | string           | OAFeat       | Single date+time, or a range ('/' seperator), formatted to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). Use double dots `..` for open date ranges. |
 | intersects   | GeoJSON Geometry | STAC         | Searches items by performing intersection between their geometry and provided GeoJSON geometry.  All GeoJSON geometry types must be supported. |
-| ids          | \[string]        | STAC         | Array of Item ids to return. All other filter parameters that further restrict the number of search results (except `next` and `limit`) are ignored |
+| ids          | \[string]        | STAC         | Array of Item ids to return. |
 | collections  | \[string]        | STAC         | Array of one or more Collection IDs to include in the search for items. Only Items in one of the provided Collections will be searched |
 
 Only one of either **intersects** or **bbox** should be specified.  If both are specified, a 400 Bad Request response 

--- a/item-search/openapi.yaml
+++ b/item-search/openapi.yaml
@@ -237,8 +237,7 @@ components:
     ids:
       type: array
       description: |-
-        Array of Item ids to return. All other filter parameters that further
-        restrict the number of search results are ignored
+        Array of Item ids to return.
       items:
         type: string
     datetimeFilter:

--- a/item-search/openapi.yaml
+++ b/item-search/openapi.yaml
@@ -98,8 +98,7 @@ components:
       name: ids
       in: query
       description: |-
-        Array of Item ids to return. All other filter parameters that further
-        restrict the number of search results are ignored
+        Array of Item ids to return.
       required: false
       schema:
         $ref: '#/components/schemas/ids'


### PR DESCRIPTION
**Related Issue(s):** #124 


**Proposed Changes:**

1. Don't deactivate other query params when `ids` is passed to item search

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
