### PR TITLE
update stac_version references to 1.0.0 and stac api references to 1.0.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v1.0.0-beta.2] - 2020-06-01
 
 ### Added
+- Added Filter extension to integrate OAFeat Part 3 CQL
 - Catalog and Collection definitions now have required field "type"
 - Added recommendation to enable CORS for public APIs
 
 ### Changed
 - Updated all STAC versions to 1.0.0
-- Added Filter extension to integrate OAFeat Part 3 CQL
 - Passing the `ids` parameter to an item search does not deactivate other query parameters [#125](https://github.com/radiantearth/stac-api-spec/pull/125)
 - The first extent in a Collection is always the overall extent, followed by more specific extents. [opengeospatial/ogcapi-features#520](https://github.com/opengeospatial/ogcapi-features/pull/520)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,4 +71,5 @@ See the [stac-spec CHANGELOG](https://github.com/radiantearth/stac-spec/blob/v0.
 for STAC API releases prior to or equal to version 0.9.0.
 
 [Unreleased]: <https://github.com/radiantearth/stac-api-spec/compare/master...dev>
+[v1.0.0-beta.1]: <https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-beta.1>
 [v1.0.0-beta.2]: <https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-beta.2>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+  
+## [v1.0.0-beta.2] - 2020-06-01
+
+### Added
 - Catalog and Collection definitions now have required field "type"
 - Added recommendation to enable CORS for public APIs
 
 ### Changed
+- Updated all STAC versions to 1.0.0
 - Added Filter extension to integrate OAFeat Part 3 CQL
 - Passing the `ids` parameter to an item search does not deactivate other query parameters [#125](https://github.com/radiantearth/stac-api-spec/pull/125)
 - The first extent in a Collection is always the overall extent, followed by more specific extents. [opengeospatial/ogcapi-features#520](https://github.com/opengeospatial/ogcapi-features/pull/520)
 
 ### Deprecated
-- Query extension is now deprecated. Replaced by the Filter extension using OGC CQL
+- Query extension is now deprecated. Replaced by the Filter extension using OGC CQL.
 
 ### Removed
 
@@ -58,4 +71,4 @@ See the [stac-spec CHANGELOG](https://github.com/radiantearth/stac-spec/blob/v0.
 for STAC API releases prior to or equal to version 0.9.0.
 
 [Unreleased]: <https://github.com/radiantearth/stac-api-spec/compare/master...dev>
-[v1.0.0-beta.1]: <https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-beta.1>
+[v1.0.0-beta.2]: <https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-beta.2>

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ to search STAC catalogs, where the features returned are STAC [Item](stac-spec/i
 that have common properties, links to their assets and geometries that represent the footprints of the geospatial assets.
 
 The specification for STAC API is provided as files that follow the [OpenAPI](http://openapis.org/) 3.0 specification, 
-rendered online into HTML at <https://api.stacspec.org/v1.0.0-beta.1>, in addition to human-readable documentation.  
+rendered online into HTML at <https://api.stacspec.org/v1.0.0-beta.2>, in addition to human-readable documentation.  
 
 ## Stability Note
 

--- a/build/swagger-config.yaml
+++ b/build/swagger-config.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: STAC API - Complete
-  version: 1.0.0-beta.1
+  version: 1.0.0-beta.2
 apis:
   - url: 'build/core/openapi.yaml'
     paths:

--- a/core/README.md
+++ b/core/README.md
@@ -4,9 +4,9 @@
   - [Recommended Link Relations at `/`](#recommended-link-relations-at-)
   - [Example Landing Page for STAC API - Core](#example-landing-page-for-stac-api---core)
 
-- **OpenAPI specification:** [openapi.yaml](openapi.yaml) describes the core endpoints ([rendered version](https://api.stacspec.org/v1.0.0-beta.1/core)),
+- **OpenAPI specification:** [openapi.yaml](openapi.yaml) describes the core endpoints ([rendered version](https://api.stacspec.org/v1.0.0-beta.2/core)),
   and [commons.yaml](commons.yaml) is the OpenAPI version of the core [STAC spec](../stac-spec) JSON Schemas.
-- **Conformance URI:** <https://api.stacspec.org/v1.0.0-beta.1/core>
+- **Conformance URI:** <https://api.stacspec.org/v1.0.0-beta.2/core>
 - **Extension [Maturity Classification](../extensions.md#extension-maturity):** Pilot
 - **Dependencies**: None
 
@@ -70,12 +70,12 @@ the [overview](../overview.md#example-landing-page) document.
 
 ```json
 {
-    "stac_version": "1.0.0-beta.2",
+    "stac_version": "1.0.0",
     "id": "example-stac",
     "title": "A simple STAC API Example",
     "description": "This Catalog aims to demonstrate the a simple landing page",
     "conformsTo" : [
-        "https://api.stacspec.org/v1.0.0-beta.1/core"
+        "https://api.stacspec.org/v1.0.0-beta.2/core"
     ],
     "links": [
         {

--- a/core/commons.yaml
+++ b/core/commons.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: The SpatioTemporal Asset Catalog API - Commons
   description: This is the OpenAPI version of the core STAC spec JSON Schemas.
-  version: 1.0.0-beta.1
+  version: 1.0.0-beta.2
 paths: {}
 components:
   responses:
@@ -100,7 +100,7 @@ components:
         license:
           $ref: '#/components/schemas/license'
         extent:
-          $ref: "#/components/schemas/extent"
+          $ref: '#/components/schemas/extent'
         providers:
           $ref: '#/components/schemas/providers'
         links:
@@ -148,7 +148,7 @@ components:
                       - type: string
                       - type: number
       example:
-        stac_version: 1.0.0-beta.2
+        stac_version: 1.0.0
         stac_extensions: []
         type: Collection
         id: Sentinel-2
@@ -272,7 +272,7 @@ components:
             bbox:
               description: |-
                 One or more bounding boxes that describe the spatial extent of the dataset.
-                
+
                 The first bounding box describes the overall spatial
                 extent of the data. All subsequent bounding boxes describe 
                 more precise bounding boxes, e.g., to identify clusters of data.
@@ -437,7 +437,7 @@ components:
         `proprietary` if the license is not on the SPDX license list or
         `various` if multiple licenses apply. In these two cases links to the
         license texts SHOULD be added, see the `license` link relation type.
-        
+
         Non-SPDX licenses SHOULD add a link to the license text with the
         `license` relation in the links section. The license text MUST NOT be
         provided as a value of this field. If there is no public license URL
@@ -556,7 +556,7 @@ components:
     stac_version:
       title: STAC version
       type: string
-      example: 1.0.0-beta.2
+      example: 1.0.0
     stac_extensions:
       title: STAC extensions
       type: array
@@ -569,7 +569,7 @@ components:
           - title: Reference to a core extension
             type: string
     item:
-      description:  A GeoJSON Feature augmented with foreign members that contain values relevant to a STAC entity
+      description: A GeoJSON Feature augmented with foreign members that contain values relevant to a STAC entity
       type: object
       required:
         - stac_version
@@ -590,7 +590,7 @@ components:
         bbox:
           $ref: '#/components/schemas/bbox'
         geometry:
-          $ref: "#/components/schemas/geometryGeoJSON"
+          $ref: '#/components/schemas/geometryGeoJSON'
         type:
           $ref: '#/components/schemas/itemType'
         links:
@@ -713,16 +713,16 @@ components:
               type: string
             description: Purposes of the asset
             example:
-                  - thumbnail
+              - thumbnail
     geometryGeoJSON:
       oneOf:
-      - $ref: "#/components/schemas/pointGeoJSON"
-      - $ref: "#/components/schemas/multipointGeoJSON"
-      - $ref: "#/components/schemas/linestringGeoJSON"
-      - $ref: "#/components/schemas/multilinestringGeoJSON"
-      - $ref: "#/components/schemas/polygonGeoJSON"
-      - $ref: "#/components/schemas/multipolygonGeoJSON"
-      - $ref: "#/components/schemas/geometrycollectionGeoJSON"
+        - $ref: '#/components/schemas/pointGeoJSON'
+        - $ref: '#/components/schemas/multipointGeoJSON'
+        - $ref: '#/components/schemas/linestringGeoJSON'
+        - $ref: '#/components/schemas/multilinestringGeoJSON'
+        - $ref: '#/components/schemas/polygonGeoJSON'
+        - $ref: '#/components/schemas/multipolygonGeoJSON'
+        - $ref: '#/components/schemas/geometrycollectionGeoJSON'
     geometrycollectionGeoJSON:
       type: object
       required:
@@ -736,7 +736,7 @@ components:
         geometries:
           type: array
           items:
-            $ref: "#/components/schemas/geometryGeoJSON"
+            $ref: '#/components/schemas/geometryGeoJSON'
     linestringGeoJSON:
       type: object
       required:
@@ -862,7 +862,7 @@ components:
         features:
           type: array
           items:
-            $ref: "#/components/schemas/featureGeoJSON"
+            $ref: '#/components/schemas/featureGeoJSON'
     featureGeoJSON:
       type: object
       required:
@@ -875,7 +875,7 @@ components:
           enum:
             - Feature
         geometry:
-          $ref: "#/components/schemas/geometryGeoJSON"
+          $ref: '#/components/schemas/geometryGeoJSON'
         properties:
           type: object
           nullable: true

--- a/core/openapi.yaml
+++ b/core/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: The SpatioTemporal Asset Catalog API - Core
-  version: 1.0.0-beta.1
+  version: 1.0.0-beta.2
   description: >-
     This is an OpenAPI definition of the core SpatioTemporal Asset Catalog API
     specification. Any service that implements this endpoint to allow discovery of
@@ -58,12 +58,12 @@ components:
             $ref: '#/components/schemas/landingPage'
           example:
             type: Catalog
-            stac_version: 1.0.0-beta.1
+            stac_version: 1.0.0
             id: sentinel
             title: Copernicus Sentinel Imagery
             description: Catalog of Copernicus Sentinel 1 and 2 imagery.
             conformsTo:
-              - 'https://api.stacspec.org/v1.0.0-beta.1/core'
+              - 'https://api.stacspec.org/v1.0.0-beta.2/core'
             links:
               - href: 'http://data.example.org/'
                 rel: self

--- a/extensions.md
+++ b/extensions.md
@@ -22,7 +22,7 @@ on the extension.
 | Pilot                   | 1           | Idea is fleshed out, with examples and a JSON schema, and implemented in one or more catalogs. Additional implementations encouraged to help give feedback | Approaching stability - breaking changes are not anticipated but can easily come from additional feedback |
 | Candidate               | 3           | A number of implementers are using it and are standing behind it as a solid extension. Can generally count on an extension at this maturity level | Mostly stable, breaking changes require a new version and minor changes are unlikely. |
 | Stable                  | 6           | Highest current level of maturity. The community of extension maintainers commits to a STAC review process for any changes, which are not made lightly. | Completely stable, all changes require a new version number and review process. |
-| Deprecated              | N/A         | A previous extension that has likely been superceded by a newer one or did not work out for some reason. | DO NOT USE, is not supported |
+| Deprecated              | N/A         | A previous extension that has likely been superseded by a newer one or did not work out for some reason. | DO NOT USE, is not supported |
 
 Maturity mostly comes through diverse implementations, so the minimum number of implementations
 column is the main gating function for an extension to mature. But extension authors can also
@@ -67,14 +67,13 @@ the service supports. This are listed at the top of each extension description, 
 
 | Extension Name | Conformance Class URIs  |
 |---------------|-------------------------|
-| [Fields](item-search/README.md#fields)   | <https://api.stacspec.org/v1.0.0-beta.1/item-search#fields>  |
-| [Filter](item-search/README.md#filter)   | <https://api.stacspec.org/v1.0.0-beta.1/item-search#filter:filter><br/><https://api.stacspec.org/v1.0.0-beta.1/item-search#filter:simple-cql><br/><https://api.stacspec.org/v1.0.0-beta.1/item-search#filter:item-search-filter><br/><https://api.stacspec.org/v1.0.0-beta.1/item-search#filter:cql-text><br/><https://api.stacspec.org/v1.0.0-beta.1/item-search#filter:cql-json> |
-| [Context](item-search/README.md#context) | <https://api.stacspec.org/v1.0.0-beta.1/item-search#context> |
-| [Sort](item-search/README.md#sort)       | <https://api.stacspec.org/v1.0.0-beta.1/item-search#sort>    |
-| [Transaction](ogcapi-features/extensions/transaction/README.md) | <https://api.stacspec.org/v1.0.0-beta.1/ogcapi-features/extensions/transaction> |
-| [Items and Collections API Version](ogcapi-features/extensions/version/README.md) | <https://api.stacspec.org/v1.0.0-beta.1/ogcapi-features/extensions/version> |
-| [Query](item-search/README.md#query)     | <https://api.stacspec.org/v1.0.0-beta.1/item-search#query> |
-
+| [Fields](item-search/README.md#fields)   | <https://api.stacspec.org/v1.0.0-beta.2/item-search#fields>  |
+| [Filter](item-search/README.md#filter)   | <https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:filter><br/><https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:simple-cql><br/><https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:item-search-filter><br/><https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:cql-text><br/><https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:cql-json> |
+| [Context](item-search/README.md#context) | <https://api.stacspec.org/v1.0.0-beta.2/item-search#context> |
+| [Sort](item-search/README.md#sort)       | <https://api.stacspec.org/v1.0.0-beta.2/item-search#sort>    |
+| [Transaction](ogcapi-features/extensions/transaction/README.md) | <https://api.stacspec.org/v1.0.0-beta.2/ogcapi-features/extensions/transaction> |
+| [Items and Collections API Version](ogcapi-features/extensions/version/README.md) | <https://api.stacspec.org/v1.0.0-beta.2/ogcapi-features/extensions/version> |
+| [Query](item-search/README.md#query)     | <https://api.stacspec.org/v1.0.0-beta.2/item-search#query> |
 
 ## Third-party / vendor extensions
 

--- a/fragments/context/README.md
+++ b/fragments/context/README.md
@@ -1,7 +1,7 @@
 # STAC API - Context Fragment
 
 - **OpenAPI specification:** [openapi.yaml](openapi.yaml)
-- **Conformance Class:** <https://api.stacspec.org/v1.0.0-beta.1/item-search#context>
+- **Conformance Class:** <https://api.stacspec.org/v1.0.0-beta.2/item-search#context>
 - **Fragment [Maturity Classification](../../extensions.md#extension-maturity):** Pilot
 - **Dependents:**
   - [Item Search](../../item-search)
@@ -20,16 +20,16 @@ implementing OGC API - Features.*
 
 ## ItemCollection fields
 
-| Element   | Type                              | Description |
-| --------- | --------------------------------- | ----------- |
+| Element   | Type                              | Description                                                                                      |
+| --------- | --------------------------------- | ------------------------------------------------------------------------------------------------ |
 | `context` | [Context Object](#context-object) | **REQUIRED.** The search-related metadata for the [ItemCollection](../itemcollection/README.md). |
 
 ## Context Object
 
-| Element  | Type            | Description |
-| -------- | --------------- | ----------- |
-| returned | integer         | **REQUIRED** The count of results returned by this response. Equal to the cardinality of features array. |
-| limit    | integer \| null | The maximum number of results to which the result was limited. |
+| Element  | Type            | Description                                                                                                                           |
+| -------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| returned | integer         | **REQUIRED** The count of results returned by this response. Equal to the cardinality of features array.                              |
+| limit    | integer \| null | The maximum number of results to which the result was limited.                                                                        |
 | matched  | integer         | The count of total number of results that match for this query, possibly estimated, particularly in the context of NoSQL data stores. |
 
 The default sort of query results should be stable, but may not be depending on the data store's sorting performance.

--- a/fragments/context/examples/example.json
+++ b/fragments/context/examples/example.json
@@ -7,7 +7,7 @@
   },
   "features": [
       {
-        "stac_version": "1.0.0-beta.2",
+        "stac_version": "1.0.0",
         "stac_extensions": [],
         "type": "Feature",
         "id": "CS3-20160503_132131_05",

--- a/fragments/context/openapi.yaml
+++ b/fragments/context/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: The SpatioTemporal Asset Catalog API - Context
   description: Adds search related metadata (context) to GeoJSON Responses.
-  version: 1.0.0-beta.1
+  version: 1.0.0-beta.2
 paths: {}
 components:
   schemas:

--- a/fragments/fields/README.md
+++ b/fragments/fields/README.md
@@ -1,7 +1,7 @@
 # STAC API - Fields Fragment
 
 - **OpenAPI specification:** [openapi.yaml](openapi.yaml)
-- **Conformance Class:** <https://api.stacspec.org/v1.0.0-beta.1/item-search#fields>
+- **Conformance Class:** <https://api.stacspec.org/v1.0.0-beta.2/item-search#fields>
 - **Fragment [Maturity Classification](../../extensions.md#extension-maturity):** Pilot
 - **Dependents:**
   - [Item Search](../../item-search)

--- a/fragments/fields/openapi.yaml
+++ b/fragments/fields/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: The SpatioTemporal Asset Catalog API - Fields
   description: Adds parameter to control which fields are returned in the response.
-  version: 1.0.0-beta.1
+  version: 1.0.0-beta.2
 paths: {}
 components:
   parameters:

--- a/fragments/filter/README.md
+++ b/fragments/filter/README.md
@@ -335,9 +335,9 @@ In an implementation that supports Simple CQL, the Landing Page (`/`) should ret
     "https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:cql-text",
     "https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:cql-json",
 
-    "http://stacspec.org/spec/api/1.0.0-beta.2/core",
-    "http://stacspec.org/spec/api/1.0.0-beta.2/req/stac-search",
-    "http://stacspec.org/spec/api/1.0.0-beta.2/req/stac-response"
+    "http://api.stacspec.org/v1.0.0-beta.2/core",
+    "http://api.stacspec.org/v1.0.0-beta.2/req/stac-search",
+    "http://api.stacspec.org/v1.0.0-beta.2/req/stac-response"
   ],
   "links": [
     {

--- a/fragments/filter/README.md
+++ b/fragments/filter/README.md
@@ -2,16 +2,16 @@
 
 - **OpenAPI specification:** [openapi.yaml](openapi.yaml)
 - **Conformance Classes:** 
-  - Filter: <https://api.stacspec.org/v1.0.0-beta.1/item-search#filter:filter>
-  - Simple CQL: <https://api.stacspec.org/v1.0.0-beta.1/item-search#filter:simple-cql>
-  - Item Search Filter: <https://api.stacspec.org/v1.0.0-beta.1/item-search#filter:item-search-filter>
-  - CQL Text: <https://api.stacspec.org/v1.0.0-beta.1/item-search#filter:cql-text>
-  - CQL JSON: <https://api.stacspec.org/v1.0.0-beta.1/item-search#filter:cql-json>
-  - Enhanced Spatial Operators: <https://api.stacspec.org/v1.0.0-beta.1/item-search#filter:enhanced-spatial-operators>
-  - Enhanced Temporal Operators: <https://api.stacspec.org/v1.0.0-beta.1/item-search#filter:enhanced-temporal-operators>
-  - Functions: <https://api.stacspec.org/v1.0.0-beta.1/item-search#filter:functions>
-  - Arithmetic: <https://api.stacspec.org/v1.0.0-beta.1/item-search#filter:arithmetic>
-  - Arrays: <https://api.stacspec.org/v1.0.0-beta.1/item-search#filter:arrays>
+  - Filter: <https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:filter>
+  - Simple CQL: <https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:simple-cql>
+  - Item Search Filter: <https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:item-search-filter>
+  - CQL Text: <https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:cql-text>
+  - CQL JSON: <https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:cql-json>
+  - Enhanced Spatial Operators: <https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:enhanced-spatial-operators>
+  - Enhanced Temporal Operators: <https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:enhanced-temporal-operators>
+  - Functions: <https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:functions>
+  - Arithmetic: <https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:arithmetic>
+  - Arrays: <https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:arrays>
 - **Extension [Maturity Classification](../../extensions.md#extension-maturity):** Pilot
 - **Dependents:**
   - [Item Search](../../item-search)
@@ -119,23 +119,23 @@ their underlying datastore, e.g., Elasticsearch does not support the spatial pre
 Enhanced Spatial Operators conformance class.
 
 The STAC API Filter Extension reuses the definitions of several conformance classes defined in OAFeat CQL, but with a prefix of 
-`https://api.stacspec.org/v1.0.0-beta.1/item-search#filter:` instead of `http://www.opengis.net/spec/ogcapi-features-3/1.0/req/`.
+`https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:` instead of `http://www.opengis.net/spec/ogcapi-features-3/1.0/req/`.
 
 The implementation must support these conformance classes:
 
-- Filter (`https://api.stacspec.org/v1.0.0-beta.1/item-search#filter:filter`) defines the Queryables mechanism and 
+- Filter (`https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:filter`) defines the Queryables mechanism and 
   parameters `filter-lang`, `filter-crs`, and `filter`.
-- Simple CQL (`https://api.stacspec.org/v1.0.0-beta.1/item-search#filter:simple-cql`) defines the query language used 
+- Simple CQL (`https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:simple-cql`) defines the query language used 
   for the `filter` parameter defined by Filter.
-- Item Search Filter (`https://api.stacspec.org/v1.0.0-beta.1/item-search#filter:item-search-filter`) binds the Filter and Simple CQL
+- Item Search Filter (`https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:item-search-filter`) binds the Filter and Simple CQL
   conformance classes to apply to the Item Search endpoint (`/search`).  This class is the correlate of the OAFeat CQL Features 
   Filter class that binds Filter and Simple CQL to the Features resource (`/collections/{cid}/items`).
 
 The implementation must support at least one of the "CQL Text" or "CQL JSON" conformance classes that define the CQL format
 used in the filter parameter:
 
-- CQL Text (`https://api.stacspec.org/v1.0.0-beta.1/item-search#filter:cql-text`) defines that the CQL Text format is supported by Item Search.
-- CQL JSON (`https://api.stacspec.org/v1.0.0-beta.1/item-search#filter:cql-json`) defines that the CQL JSON format is supported by Item Search
+- CQL Text (`https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:cql-text`) defines that the CQL Text format is supported by Item Search.
+- CQL JSON (`https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:cql-json`) defines that the CQL JSON format is supported by Item Search
 
 If both are advertised as being supported, it is only 
 required that both be supported for GET query parameters, and that only that CQL JSON be supported for POST JSON requests. 
@@ -329,15 +329,15 @@ In an implementation that supports Simple CQL, the Landing Page (`/`) should ret
     
     "http://www.opengis.net/spec/ogcapi_common-2/1.0/req/collections",
 
-    "https://api.stacspec.org/v1.0.0-beta.1/item-search#filter:filter",
-    "https://api.stacspec.org/v1.0.0-beta.1/item-search#filter:features-filter",
-    "https://api.stacspec.org/v1.0.0-beta.1/item-search#filter:simple-cql",
-    "https://api.stacspec.org/v1.0.0-beta.1/item-search#filter:cql-text",
-    "https://api.stacspec.org/v1.0.0-beta.1/item-search#filter:cql-json",
+    "https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:filter",
+    "https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:features-filter",
+    "https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:simple-cql",
+    "https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:cql-text",
+    "https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:cql-json",
 
-    "http://stacspec.org/spec/api/1.0.0-beta.1/core",
-    "http://stacspec.org/spec/api/1.0.0-beta.1/req/stac-search",
-    "http://stacspec.org/spec/api/1.0.0-beta.1/req/stac-response"
+    "http://stacspec.org/spec/api/1.0.0-beta.2/core",
+    "http://stacspec.org/spec/api/1.0.0-beta.2/req/stac-search",
+    "http://stacspec.org/spec/api/1.0.0-beta.2/req/stac-response"
   ],
   "links": [
     {
@@ -625,7 +625,7 @@ A sample STAC Item (excluding `assets`) is:
 ```json
 {
   "type": "Feature",
-  "stac_version": "1.0.0-beta.2",
+  "stac_version": "1.0.0",
   "stac_extensions": [
     "eo",
     "view",

--- a/fragments/filter/openapi.yaml
+++ b/fragments/filter/openapi.yaml
@@ -2,10 +2,10 @@ openapi: 3.0.3
 info:
   title: The SpatioTemporal Asset Catalog API - Filter
   description: Adds parameters to compare properties and only return the items that match
-  version: 1.0.0-beta.1
+  version: 1.0.0-beta.2
 
 paths:
-  "/":
+  '/':
     description: Landing Page
     get:
       responses:
@@ -29,7 +29,7 @@ paths:
         - Queryables
       # parameters:
       # todo: may have collections parameter in the future
-      responses: 
+      responses:
         '200':
           description: A JSON Schema defining the Queryables allowed in CQL expressions
           content:
@@ -47,7 +47,7 @@ paths:
             queryables:
               operationId: getQueryables
               description: |-
-                A link with rel=queryables for queryables to only apply to this collection.        
+                A link with rel=queryables for queryables to only apply to this collection.
   /collections/{collectionId}/queryables:
     get:
       summary: Get the JSON Schema defining the list of variable terms that can be used in CQL expressions.
@@ -58,7 +58,7 @@ paths:
         Common Query Language (CQL) specification.
       tags:
         - Queryables
-      responses: 
+      responses:
         '200':
           description: A JSON Schema defining the Queryables allowed in CQL expressions filtering only that collection
           content:
@@ -75,7 +75,7 @@ components:
       in: query
       description: |-
         **Extension:** Filter
-      
+
         A CQL filter expression for filtering items.
       required: true
       schema:
@@ -88,18 +88,18 @@ components:
       in: query
       description: |-
         **Extension:** Filter
-      
+
         The CQL filter encoding that the 'filter' value uses. Must be one of 'cql-text' or 'cql-json'.
       required: false
       schema:
-         $ref: '#/components/schemas/filter-lang'
+        $ref: '#/components/schemas/filter-lang'
     filter-crs:
       name: filter-crs
       x-stac-api-fragment: filter
       in: query
       description: |-
         **Extension:** Filter
-      
+
         The CRS used by spatial predicates in the filter parameter. In STAC API, only value that must be accepted
         is 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'.
       required: false
@@ -112,7 +112,7 @@ components:
       description: |-
         **Optional Extension:** Filter
 
-        A filter for properties in Items.      
+        A filter for properties in Items.
       properties:
         filter:
           $ref: '#/components/schemas/filter-cql-json'
@@ -132,7 +132,7 @@ components:
       description: |
         The CQL filter encoding that the 'filter' value uses.
       type: string
-      enum: 
+      enum:
         - 'cql-text'
         - 'cql-json'
     filter-crs:

--- a/fragments/itemcollection/examples/itemcollection-sample-full.json
+++ b/fragments/itemcollection/examples/itemcollection-sample-full.json
@@ -1,10 +1,10 @@
 {
-  "stac_version": "1.0.0-beta.2",
+  "stac_version": "1.0.0",
   "stac_extensions": [],
   "type": "FeatureCollection",
   "features": [
     {
-      "stac_version": "1.0.0-beta.2",
+      "stac_version": "1.0.0",
       "stac_extensions": [],
       "type": "Feature",
       "id": "CS3-20160503_132131_05",

--- a/fragments/itemcollection/examples/itemcollection-sample-minimal.json
+++ b/fragments/itemcollection/examples/itemcollection-sample-minimal.json
@@ -1,5 +1,5 @@
 {
-  "stac_version": "1.0.0-beta.2",
+  "stac_version": "1.0.0",
   "stac_extensions": [],
   "type": "FeatureCollection",
   "features": []

--- a/fragments/itemcollection/openapi.yaml
+++ b/fragments/itemcollection/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: The SpatioTemporal Asset Catalog API - Item Collection
   description: The specification for a set of items, e.g. returned by a search.
-  version: 1.0.0-beta.1
+  version: 1.0.0-beta.2
 paths: {}
 components:
   schemas:

--- a/fragments/query/README.md
+++ b/fragments/query/README.md
@@ -1,7 +1,7 @@
 # STAC API - Query Fragment
 
 - **OpenAPI specification:** [openapi.yaml](openapi.yaml)
-- **Conformance Class:** <https://api.stacspec.org/v1.0.0-beta.1/item-search#query>
+- **Conformance Class:** <https://api.stacspec.org/v1.0.0-beta.2/item-search#query>
 - **Extension [Maturity Classification](../../extensions.md#extension-maturity):** Deprecated in  
   favor of the [Filter Extension](../filter/README.md) using [CQL](http://docs.opengeospatial.org/DRAFTS/19-079.html).
 - **Dependents:**

--- a/fragments/query/openapi.yaml
+++ b/fragments/query/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: The SpatioTemporal Asset Catalog API - Query
   description: Adds parameter to compare properties and only return the items that match
-  version: 1.0.0-beta.1
+  version: 1.0.0-beta.2
 paths: {}
 components:
   parameters:
@@ -12,7 +12,7 @@ components:
       in: query
       description: |-
         **Optional Extension:** Query
-      
+
         Query for properties in items.
         Use the JSON form of the query used in POST.
       required: false
@@ -24,7 +24,7 @@ components:
       x-stac-api-fragment: query
       description: |-
         **Optional Extension:** Query
-      
+
         Allows users to query properties for specific values
       properties:
         query:

--- a/fragments/sort/README.md
+++ b/fragments/sort/README.md
@@ -1,7 +1,7 @@
 # STAC API - Sort Fragment
 
 - **OpenAPI specification:** [openapi.yaml](openapi.yaml)
-- **Conformance Class:** <https://api.stacspec.org/v1.0.0-beta.1/item-search#sort>
+- **Conformance Class:** <https://api.stacspec.org/v1.0.0-beta.2/item-search#sort>
 - **Fragment [Maturity Classification](../../extensions.md#extension-maturity):** Pilot
 - **Dependents:**
   - [Item Search](../../item-search)

--- a/fragments/sort/openapi.yaml
+++ b/fragments/sort/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: The SpatioTemporal Asset Catalog API - Sort
   description: Adds Parameter to control sorting of returns results.
-  version: 1.0.0-beta.1
+  version: 1.0.0-beta.2
 paths: {}
 components:
   parameters:
@@ -27,7 +27,7 @@ components:
       x-stac-api-fragment: sort
       description: |-
         **Optional Extension:** Sort
-        
+
         Sort the results.
       properties:
         sortby:

--- a/item-search/README.md
+++ b/item-search/README.md
@@ -19,8 +19,8 @@
     - [Context](#context)
     - [Query](#query)
 
-- **OpenAPI specification:** [openapi.yaml](openapi.yaml) ([rendered version](https://api.stacspec.org/v1.0.0-beta.1/item-search))
-- **Conformance URI:** <https://api.stacspec.org/v1.0.0-beta.1/item-search>
+- **OpenAPI specification:** [openapi.yaml](openapi.yaml) ([rendered version](https://api.stacspec.org/v1.0.0-beta.2/item-search))
+- **Conformance URI:** <https://api.stacspec.org/v1.0.0-beta.2/item-search>
 - **Dependencies**: [STAC API - Core](../core)
 - **Examples**: [examples.md](examples.md)
 
@@ -215,13 +215,13 @@ the [overview](../overview.md#example-landing-page) document.
 
 ```json
 {
-    "stac_version": "1.0.0-beta.2",
+    "stac_version": "1.0.0",
     "id": "example-stac",
     "title": "A simple STAC API Example",
     "description": "This Catalog aims to demonstrate the a simple landing page",
     "conformsTo" : [
-        "https://api.stacspec.org/v1.0.0-beta.1/core",
-        "https://api.stacspec.org/v1.0.0-beta.1/item-search"
+        "https://api.stacspec.org/v1.0.0-beta.2/core",
+        "https://api.stacspec.org/v1.0.0-beta.2/item-search"
     ],
     "links": [
         {
@@ -262,7 +262,7 @@ the root (`/`) landing page, to indicate to clients that they will respond prope
 
 ### Fields
 
-- **Conformance URI:** <https://api.stacspec.org/v1.0.0-beta.1/item-search#fields>
+- **Conformance URI:** <https://api.stacspec.org/v1.0.0-beta.2/item-search#fields>
 - **Extension [Maturity Classification](../extensions.md#extension-maturity):** Pilot
 - **Definition**: [STAC API - Fields Fragment](../fragments/fields/)
 
@@ -274,7 +274,7 @@ through the use of a `fields` parameter. The full description of how this extens
 
 ### Filter
 
-- **Conformance URI:** <https://api.stacspec.org/v1.0.0-beta.1/item-search#filter>
+- **Conformance URI:** <https://api.stacspec.org/v1.0.0-beta.2/item-search#filter>
 - **Extension [Maturity Classification](../extensions.md#extension-maturity):** Pilot
 - **Definition**: [STAC API - Filter Fragment](../fragments/filter/)
 
@@ -286,7 +286,7 @@ fragment](../fragments/filter/).
 
 ### Sort
 
-- **Conformance URI:** <https://api.stacspec.org/v1.0.0-beta.1/item-search#sort>
+- **Conformance URI:** <https://api.stacspec.org/v1.0.0-beta.2/item-search#sort>
 - **Extension [Maturity Classification](../extensions.md#extension-maturity):** Pilot
 - **Definition**: [STAC API - Sort Fragment](../fragments/sort/)
 
@@ -299,7 +299,7 @@ of this extension can be found in the [sort fragment](../fragments/sort).
 
 ### Context
 
-- **Conformance URI:** <https://api.stacspec.org/v1.0.0-beta.1/item-search#context>
+- **Conformance URI:** <https://api.stacspec.org/v1.0.0-beta.2/item-search#context>
 - **Extension [Maturity Classification](../extensions.md#extension-maturity):** Pilot
 - **Definition**: [STAC API - Context Fragment](../fragments/context/)
 
@@ -309,7 +309,7 @@ The full description and examples of this are found in the [context fragment](..
 
 ### Query
 
-- **Conformance URI:** <https://api.stacspec.org/v1.0.0-beta.1/item-search#query>
+- **Conformance URI:** <https://api.stacspec.org/v1.0.0-beta.2/item-search#query>
 - **Extension [Maturity Classification](../extensions.md#extension-maturity):** Deprecated
 - **Definition**: [STAC API - Query Fragment](../fragments/query/)
 

--- a/item-search/openapi.yaml
+++ b/item-search/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: The SpatioTemporal Asset Catalog API - Item Search
-  version: 1.0.0-beta.1
+  version: 1.0.0-beta.2
   description: >-
     This is an OpenAPI definition of the SpatioTemporal Asset Catalog API Item Search
     specification.
@@ -22,7 +22,7 @@ paths:
       description: |-
         Retrieve Items matching filters. Intended as a shorthand API for simple
         queries.
-        
+
         This method is optional, but you MUST implement `POST /search` if you
         want to implement this method.
 
@@ -50,9 +50,9 @@ paths:
             application/geo+json:
               schema:
                 allOf:
-                - $ref: '../fragments/itemcollection/openapi.yaml#/components/schemas/itemCollection'
-                # extensions
-                - $ref: '../fragments/context/openapi.yaml#/components/schemas/itemCollection'
+                  - $ref: '../fragments/itemcollection/openapi.yaml#/components/schemas/itemCollection'
+                  # extensions
+                  - $ref: '../fragments/context/openapi.yaml#/components/schemas/itemCollection'
             text/html:
               schema:
                 type: string
@@ -64,7 +64,7 @@ paths:
       description: |-
         retrieve items matching filters. Intended as the standard, full-featured
         query API.
-        
+
         This method is mandatory to implement if `GET /search` is implemented.
         If this endpoint is implemented on a server, it is required to add a
         link referring to this endpoint with `rel` set to `search` and `method`
@@ -76,11 +76,11 @@ paths:
           application/json:
             schema:
               allOf:
-               - $ref: '#/components/schemas/searchBody'
-              # extensions
-               - $ref: '../fragments/fields/openapi.yaml#/components/schemas/searchBody'
-               - $ref: '../fragments/filter/openapi.yaml#/components/schemas/searchBody'
-               - $ref: '../fragments/sort/openapi.yaml#/components/schemas/searchBody'
+                - $ref: '#/components/schemas/searchBody'
+                # extensions
+                - $ref: '../fragments/fields/openapi.yaml#/components/schemas/searchBody'
+                - $ref: '../fragments/filter/openapi.yaml#/components/schemas/searchBody'
+                - $ref: '../fragments/sort/openapi.yaml#/components/schemas/searchBody'
       responses:
         '200':
           description: A feature collection.
@@ -209,10 +209,10 @@ components:
       in: query
       description: |-
         The optional intersects parameter filters the result Items in the same was as bbox, only with
-        a GeoJSON Geometry rather than a bbox. 
+        a GeoJSON Geometry rather than a bbox.
       required: false
       schema:
-        $ref: "../core/commons.yaml#/components/schemas/geometryGeoJSON"
+        $ref: '../core/commons.yaml#/components/schemas/geometryGeoJSON'
       style: form
       explode: false
   schemas:
@@ -263,7 +263,7 @@ components:
       description: Only returns items that intersect with the provided polygon.
       properties:
         intersects:
-          $ref: "../core/commons.yaml#/components/schemas/geometryGeoJSON"
+          $ref: '../core/commons.yaml#/components/schemas/geometryGeoJSON'
     limitFilter:
       type: object
       description: Only returns maximum number of results (page size)

--- a/ogcapi-features/README.md
+++ b/ogcapi-features/README.md
@@ -7,10 +7,10 @@
 
 *based on [**OGC API - Features - Part 1: Core**](https://www.ogc.org/standards/ogcapi-features)*
 
-- **OpenAPI specification:** [openapi.yaml](openapi.yaml) ([rendered version](https://api.stacspec.org/v1.0.0-beta.1/ogcapi-features)) 
+- **OpenAPI specification:** [openapi.yaml](openapi.yaml) ([rendered version](https://api.stacspec.org/v1.0.0-beta.2/ogcapi-features)) 
   uses all the OGC API - Features openapi fragments to describe returning STAC Item objects.
 - **Conformance URIs:**
-  - <https://api.stacspec.org/v1.0.0-beta.1/ogcapi-features> 
+  - <https://api.stacspec.org/v1.0.0-beta.2/ogcapi-features> 
   - <http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core> - [Requirements Class Core](http://docs.opengeospatial.org/is/17-069r3/17-069r3.html#rc_core))
   - <http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30> - [Requirements Class OpenAPI 3.0](http://docs.opengeospatial.org/is/17-069r3/17-069r3.html#rc_oas30))
   - <http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson> - [Requirements Class GeoJSON](http://docs.opengeospatial.org/is/17-069r3/17-069r3.html#_requirements_class_geojson))
@@ -33,15 +33,15 @@ with OAFeat clients. But specialized STAC clients will likely display results be
 The core OGC API - Features endpoints are shown below, with details provided in an 
 [OpenAPI specification document](openapi.yaml).
 
-| Endpoint                                        | Returns          | Description |
-| ----------------------------------------------- | ---------------- | ----------- |
-| `/`                                             | [Catalog](../stac-spec/catalog-spec/README.md) | Landing page, links to API capabilities |
-| `/conformance`                                  | JSON | Info about standards to which the API conforms |
-| `/collections`                                  | JSON | Object containing an array of Collection objects in the Catalog, and Link relations |
-| `/collections/{collectionId}`                   | [Collection](../stac-spec/collection-spec/README.md) | Returns single Collection JSON |
-| `/collections/{collectionId}/items`             | [ItemCollection](../fragments/itemcollection/README.md) | GeoJSON FeatureCollection-conformant entity of Item objects in collection |
-| `/collections/{collectionId}/items/{featureId}` | [Item](../stac-spec/item-spec/README.md) | Returns single Item (GeoJSON Feature) |
-| `/api`                                          | OpenAPI 3.0 JSON | Returns an OpenAPI description of the service from the `service-desc` link `rel` - not required to be `/api`, but the document is required |
+| Endpoint                                        | Returns                                                 | Description                                                                                                                                |
+| ----------------------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `/`                                             | [Catalog](../stac-spec/catalog-spec/README.md)          | Landing page, links to API capabilities                                                                                                    |
+| `/conformance`                                  | JSON                                                    | Info about standards to which the API conforms                                                                                             |
+| `/collections`                                  | JSON                                                    | Object containing an array of Collection objects in the Catalog, and Link relations                                                        |
+| `/collections/{collectionId}`                   | [Collection](../stac-spec/collection-spec/README.md)    | Returns single Collection JSON                                                                                                             |
+| `/collections/{collectionId}/items`             | [ItemCollection](../fragments/itemcollection/README.md) | GeoJSON FeatureCollection-conformant entity of Item objects in collection                                                                  |
+| `/collections/{collectionId}/items/{featureId}` | [Item](../stac-spec/item-spec/README.md)                | Returns single Item (GeoJSON Feature)                                                                                                      |
+| `/api`                                          | OpenAPI 3.0 JSON                                        | Returns an OpenAPI description of the service from the `service-desc` link `rel` - not required to be `/api`, but the document is required |
 
 The OGC API - Features is a standard API that represents collections of geospatial data. It defines the RESTful interface 
 to query geospatial data, with GeoJSON as a main return type. With OAFeat you can return any `Feature`, which is a geometry 
@@ -114,13 +114,13 @@ the [overview](../overview.md#example-landing-page) document.
 
 ```json
 {
-    "stac_version": "1.0.0-beta.2",
+    "stac_version": "1.0.0",
     "id": "example-stac",
     "title": "A simple STAC API Example",
     "description": "This Catalog aims to demonstrate the a simple landing page",
     "conformsTo" : [
-        "https://api.stacspec.org/v1.0.0-beta.1/core",
-        "https://api.stacspec.org/v1.0.0-beta.1/ogcapi-features",
+        "https://api.stacspec.org/v1.0.0-beta.2/core",
+        "https://api.stacspec.org/v1.0.0-beta.2/ogcapi-features",
         "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
         "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30",
         "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson"

--- a/ogcapi-features/extensions/transaction/README.md
+++ b/ogcapi-features/extensions/transaction/README.md
@@ -4,7 +4,7 @@
 
 - **OpenAPI specification:** [openapi.yaml](openapi.yaml)
 - **Conformance URIs:**
-  - <https://api.stacspec.org/v1.0.0-beta.1/ogcapi-features/extensions/transaction>
+  - <https://api.stacspec.org/v1.0.0-beta.2/ogcapi-features/extensions/transaction>
   - <http://www.opengis.net/spec/ogcapi-features-4/1.0/conf/simpletx>
 - **Extension [Maturity Classification](../../../extensions.md#extension-maturity):** Pilot
 - **Dependencies**: [STAC API - Features](../../README.md)
@@ -29,9 +29,9 @@ work to get it incorporated.
 
 ## Methods
 
-| Path                                                   | Content-Type Header | Description |
-| ------------------------------------------------------ | ------------------- | ----------- |
-| `POST /collections/{collectionID}/items`               | `application/json`  | Adds a new item to a collection. |
-| `PUT /collections/{collectionId}/items/{featureId}`    | `application/json`  | Updates an existing item by ID using a complete item description. |
+| Path                                                   | Content-Type Header | Description                                                                                                                      |
+| ------------------------------------------------------ | ------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `POST /collections/{collectionID}/items`               | `application/json`  | Adds a new item to a collection.                                                                                                 |
+| `PUT /collections/{collectionId}/items/{featureId}`    | `application/json`  | Updates an existing item by ID using a complete item description.                                                                |
 | `PATCH /collections/{collectionId}/items/{featureId}`  | `application/json`  | Updates an existing item by ID using a partial item description, compliant with [RFC 7386](https://tools.ietf.org/html/rfc7386). |
-| `DELETE /collections/{collectionID}/items/{featureId}` | n/a                 | Deletes an existing item by ID. |
+| `DELETE /collections/{collectionID}/items/{featureId}` | n/a                 | Deletes an existing item by ID.                                                                                                  |

--- a/ogcapi-features/extensions/transaction/openapi.yaml
+++ b/ogcapi-features/extensions/transaction/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   title: The SpatioTemporal Asset Catalog API - Transaction
-  version: 1.0.0-beta.1
+  version: 1.0.0-beta.2
   description: >-
     This is an OpenAPI definition of the SpatioTemporal Asset Catalog API Transaction
     specification.
@@ -30,9 +30,9 @@ paths:
         content:
           application/json:
             schema:
-                oneOf:
-                 - $ref: '../../../core/commons.yaml#/components/schemas/item'
-                 - $ref: '../../../fragments/itemcollection/openapi.yaml#/components/schemas/itemCollection'
+              oneOf:
+                - $ref: '../../../core/commons.yaml#/components/schemas/item'
+                - $ref: '../../../fragments/itemcollection/openapi.yaml#/components/schemas/itemCollection'
       responses:
         '201':
           description: Status of the create request.

--- a/ogcapi-features/extensions/version/README.md
+++ b/ogcapi-features/extensions/version/README.md
@@ -1,7 +1,7 @@
 # Items and Collections API Version Extension
 
 - **OpenAPI specification:** [openapi.yaml](openapi.yaml)
-- **Conformance URI:** <https://api.stacspec.org/v1.0.0-beta.1/ogcapi-features/extensions/version>
+- **Conformance URI:** <https://api.stacspec.org/v1.0.0-beta.2/ogcapi-features/extensions/version>
 - **Extension [Maturity Classification](../../../extensions.md#extension-maturity):** Proposal
 - **Dependencies**: [STAC API - Features](../../README.md)
 
@@ -12,12 +12,12 @@ incubated in STAC.
 
 ## Methods
 
-| Path                                                                     | Content-Type Header | Description |
-| ------------------------------------------------------------------------ | ------------------- | ----------- |
+| Path                                                                     | Content-Type Header | Description                                                                  |
+| ------------------------------------------------------------------------ | ------------------- | ---------------------------------------------------------------------------- |
 | `GET /collections/{collectionID}/versions`                               | `application/json`  | Returns a catalog response with links to all versions of a given collection. |
-| `GET /collections/{collectionID}/versions/{versionId}`                   | `application/json`  | Returns a collection record. |
-| `GET /collections/{collectionID}/items/{featureId}/versions`             | `application/json`  | Returns a catalog response with links to all versions of a given item. |
-| `GET /collections/{collectionID}/items/{featureId}/versions/{versionId}` | `application/json`  | Returns an item record. |
+| `GET /collections/{collectionID}/versions/{versionId}`                   | `application/json`  | Returns a collection record.                                                 |
+| `GET /collections/{collectionID}/items/{featureId}/versions`             | `application/json`  | Returns a catalog response with links to all versions of a given item.       |
+| `GET /collections/{collectionID}/items/{featureId}/versions/{versionId}` | `application/json`  | Returns an item record.                                                      |
 
 ## How It Works
 
@@ -50,12 +50,12 @@ There are many options for a versioning schema including:
 
 The extension uses [RFC5829](https://tools.ietf.org/html/rfc5829) rel types to link to different versions:
 
-| Type                | Description |
-| ------------------- | ----------- |
-| latest-version      | Points to the latest version of the record. |
-| version-history     | Points to the list of versions. |
-| predecessor-version | Points to the previous version of the document. |
-| successor-version   | Points to the successor version in the version history. |
+| Type                | Description                                                                                                                                                                           |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| latest-version      | Points to the latest version of the record.                                                                                                                                           |
+| version-history     | Points to the list of versions.                                                                                                                                                       |
+| predecessor-version | Points to the previous version of the document.                                                                                                                                       |
+| successor-version   | Points to the successor version in the version history.                                                                                                                               |
 | permalink           | Points to the permanent location of the record. This location points to a specific version, remains accessible and will not change even when there are future versions of the record. |
 
 ## Example

--- a/ogcapi-features/extensions/version/openapi.yaml
+++ b/ogcapi-features/extensions/version/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: The SpatioTemporal Asset Catalog API - Item Search
-  version: 1.0.0-beta.1
+  version: 1.0.0-beta.2
   description: >-
     This is an OpenAPI definition of the SpatioTemporal Asset Catalog API Item Search
     specification.

--- a/ogcapi-features/openapi.yaml
+++ b/ogcapi-features/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 info:
-  title: "STAC API - Features (extends OGC API - Features - Part 1: Core)"
-  version: '1.0.0-beta.1'
+  title: 'STAC API - Features (extends OGC API - Features - Part 1: Core)'
+  version: '1.0.0-beta.2'
   description: >-
     This is an OpenAPI definition of the SpatioTemporal Asset Catalog API Item Search
     specification.
@@ -38,13 +38,13 @@ paths:
               schema:
                 $ref: '../core/openapi.yaml#/components/schemas/landingPage'
               example:
-                stac_version: 1.0.0-beta.1
+                stac_version: 1.0.0-beta.2
                 type: Catalog
                 id: sentinel
                 title: Copernicus Sentinel Imagery
                 description: Catalog of Copernicus Sentinel 1 and 2 imagery.
                 conformsTo:
-                  - 'https://api.stacspec.org/v1.0.0-beta.1/core'
+                  - 'https://api.stacspec.org/v1.0.0-beta.2/core'
                   - 'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core'
                   - 'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30'
                   - 'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson'
@@ -291,15 +291,15 @@ components:
             features:
               type: array
               items:
-                $ref: "../core/commons.yaml#/components/schemas/item"
+                $ref: '../core/commons.yaml#/components/schemas/item'
             links:
               $ref: '../core/commons.yaml#/components/schemas/links'
             timeStamp:
-              $ref: "#/components/schemas/timeStamp"
+              $ref: '#/components/schemas/timeStamp'
             numberMatched:
-              $ref: "#/components/schemas/numberMatched"
+              $ref: '#/components/schemas/numberMatched'
             numberReturned:
-              $ref: "#/components/schemas/numberReturned"
+              $ref: '#/components/schemas/numberReturned'
     numberMatched:
       description: |-
         The number of features of the feature type that match the selection
@@ -413,7 +413,7 @@ components:
       content:
         application/geo+json:
           schema:
-            $ref: "../core/commons.yaml#/components/schemas/item"
+            $ref: '../core/commons.yaml#/components/schemas/item'
     InvalidParameter:
       description: |-
         A query parameter has an invalid value.

--- a/overview.md
+++ b/overview.md
@@ -20,7 +20,7 @@ off point for the more powerful capabilities - it contains a list of URL's, each
 'relationships' (`rel`) to indicate their functionality. Note that the [STAC Core specification](stac-spec) provides 
 most all the content of API responses - the STAC API is primarily concerned with the return of STAC 
 [Item](stac-spec/item-spec/README.md) and [Collection](stac-spec/collection-spec/README.md) objects via a 
-RESTful web API.  See the [rendered OpenAPI document](https://api.stacspec.org/v1.0.0-beta.1/core) for more details.
+RESTful web API.  See the [rendered OpenAPI document](https://api.stacspec.org/v1.0.0-beta.2/core) for more details.
 
 There are then two major sets of functionality that build on the core, which are designed to be complementary, letting
 implementations choose which parts they want to utilize. Most every STAC API implements at least one, and many follow
@@ -33,7 +33,7 @@ located at a `/search` endpoint. It re-uses all of the OAFeat [query
 parameters](http://docs.opengeospatial.org/is/17-069r3/17-069r3.html#_items_) specified in their 'core', and adds a 
 couple more. It does not require a full implementation of OAFeat, it is instead a simplified construct that can run a 
 search across any set of indexed STAC [`Item`](stac-spec/item-spec/README.md) objects. See the [rendered OpenAPI 
-document](https://api.stacspec.org/v1.0.0-beta.1/item-spec) for more details.
+document](https://api.stacspec.org/v1.0.0-beta.2/item-spec) for more details.
 
 ### OGC API - Features
 
@@ -49,7 +49,7 @@ is always in GeoJSON and OpenAPI is used to specify STAC API. Full compliance in
 individual `/collections/{collectionId}/items` endpoints that expose querying single collections, as OAFeat does
 not currently allow cross-collection search. And it adds a few other requirements, which are highlighted in the 
 [features description](ogcapi-features/), in order to help STAC implementors understand OAFeat without having to
-read the full spec from scratch. See the [rendered OpenAPI document](https://api.stacspec.org/v1.0.0-beta.1/ogcapi-features)
+read the full spec from scratch. See the [rendered OpenAPI document](https://api.stacspec.org/v1.0.0-beta.2/ogcapi-features)
 for more details.
 
 ### Extensions & Fragments
@@ -106,7 +106,7 @@ column is more of an example in some cases. OGC API makes some endpoint location
 STAC API is evolving to utilize OAFeat's 
 '[Conformance](http://docs.opengeospatial.org/is/17-069r3/17-069r3.html#_declaration_of_conformance_classes)' 
 JSON structure. For 
-STAC API 1.0.0-beta.1 we declare new STAC Conformance classes, with the core ones detailed in the table below. [STAC 
+STAC API 1.0.0-beta.2 we declare new STAC Conformance classes, with the core ones detailed in the table below. [STAC 
 Features](ogcapi-features) requires the core OAFeat conformance classes, and declares that those endpoints return 
 STAC Collection and Feature objects.
 The core STAC conformance classes communicate the conformance JSON only in the root (`/`) document, while OGC API 
@@ -122,9 +122,9 @@ have the URI's for conformance to actually resolve to machine-readable informati
 
 | **Name**                  | **Specified in**           | **Conformance URI**                                              | **Description**                                                                                                                                                                                                                                                                     |
 |---------------------------|----------------------------|------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| STAC Core                 | [Core](core)               | <https://api.stacspec.org/v1.0.0-beta.1/core>          | Specifies the STAC Landing page `/`, communicating conformance and available endpoints.                                                                                                                                                                                             |
-| Item Search               | [Item Search](item-search) | <https://api.stacspec.org/v1.0.0-beta.1/item-search>          | Enables search of all STAC Item objects on the server, with the STAC `[/search](#stac-api-endpoints)` endpoint.                                                                                                                                                                            |
-| STAC Features             | [STAC API - Features](ogcapi-features)  | <https://api.stacspec.org/v1.0.0-beta.1/ogcapi-features>      | Specifies the use of OGC API - Features to serve STAC Item and Collection objects                                                                                                                                                                                                        |
+| STAC Core                 | [Core](core)               | <https://api.stacspec.org/v1.0.0-beta.2/core>          | Specifies the STAC Landing page `/`, communicating conformance and available endpoints.                                                                                                                                                                                             |
+| Item Search               | [Item Search](item-search) | <https://api.stacspec.org/v1.0.0-beta.2/item-search>          | Enables search of all STAC Item objects on the server, with the STAC `[/search](#stac-api-endpoints)` endpoint.                                                                                                                                                                            |
+| STAC Features             | [STAC API - Features](ogcapi-features)  | <https://api.stacspec.org/v1.0.0-beta.2/ogcapi-features>      | Specifies the use of OGC API - Features to serve STAC Item and Collection objects                                                                                                                                                                                                        |
 
 Additional conformance classes are specified in the [STAC Extensions](extensions.md#Conformance-classes-of-extensions).
 
@@ -140,14 +140,14 @@ The Landing Page will at least have the following `conformsTo` and `links`:
 
 ```json
 {
-    "stac_version": "1.0.0-beta.2",
+    "stac_version": "1.0.0",
     "id": "example-stac",
     "title": "A simple STAC API Example",
     "description": "This Catalog aims to demonstrate the a simple landing page",
     "conformsTo" : [
-        "https://api.stacspec.org/v1.0.0-beta.1/core",
-        "https://api.stacspec.org/v1.0.0-beta.1/item-search",
-        "https://api.stacspec.org/v1.0.0-beta.1/ogcapi-features",
+        "https://api.stacspec.org/v1.0.0-beta.2/core",
+        "https://api.stacspec.org/v1.0.0-beta.2/item-search",
+        "https://api.stacspec.org/v1.0.0-beta.2/ogcapi-features",
         "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
         "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30",
         "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-spec",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "STAC API helpers to generate, serve and check the API spec.",
   "repository": "https://github.com/radiantearth/stac-api-spec",
   "license": "Apache-2.0",


### PR DESCRIPTION
**Related Issue(s):** #147


**Proposed Changes:**

1. update stac_version to be 1.0.0
2. update conformance classes to reference api 1.0.0-beta.2
3. random document formatting

**PR Checklist:**

- [X] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [X] This PR has **no** breaking changes.
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
