### PR TITLE
Change deprecated descrition; query ext as sch to be deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Query extension not deprecated; recommendation to use Filter (https://github.com/radiantearth/stac-api-spec/pull/157)
 
 ### Deprecated
 

--- a/extensions.md
+++ b/extensions.md
@@ -22,7 +22,7 @@ on the extension.
 | Pilot                   | 1           | Idea is fleshed out, with examples and a JSON schema, and implemented in one or more catalogs. Additional implementations encouraged to help give feedback | Approaching stability - breaking changes are not anticipated but can easily come from additional feedback |
 | Candidate               | 3           | A number of implementers are using it and are standing behind it as a solid extension. Can generally count on an extension at this maturity level | Mostly stable, breaking changes require a new version and minor changes are unlikely. |
 | Stable                  | 6           | Highest current level of maturity. The community of extension maintainers commits to a STAC review process for any changes, which are not made lightly. | Completely stable, all changes require a new version number and review process. |
-| Deprecated              | N/A         | A previous extension that has likely been superseded by a newer one or did not work out for some reason. | Will not be updated and may be removed in a upcoming major release. |
+| Deprecated              | N/A         | A previous extension that has likely been superseded by a newer one or did not work out for some reason. | Will not be updated and may be removed in an upcoming major release. |
 
 Maturity mostly comes through diverse implementations, so the minimum number of implementations
 column is the main gating function for an extension to mature. But extension authors can also

--- a/extensions.md
+++ b/extensions.md
@@ -22,7 +22,7 @@ on the extension.
 | Pilot                   | 1           | Idea is fleshed out, with examples and a JSON schema, and implemented in one or more catalogs. Additional implementations encouraged to help give feedback | Approaching stability - breaking changes are not anticipated but can easily come from additional feedback |
 | Candidate               | 3           | A number of implementers are using it and are standing behind it as a solid extension. Can generally count on an extension at this maturity level | Mostly stable, breaking changes require a new version and minor changes are unlikely. |
 | Stable                  | 6           | Highest current level of maturity. The community of extension maintainers commits to a STAC review process for any changes, which are not made lightly. | Completely stable, all changes require a new version number and review process. |
-| Deprecated              | N/A         | A previous extension that has likely been superseded by a newer one or did not work out for some reason. | DO NOT USE, is not supported |
+| Deprecated              | N/A         | A previous extension that has likely been superseded by a newer one or did not work out for some reason. | Will not be updated and may be removed in a upcoming major release. |
 
 Maturity mostly comes through diverse implementations, so the minimum number of implementations
 column is the main gating function for an extension to mature. But extension authors can also
@@ -58,7 +58,7 @@ This is the list of all extensions that are contained in the stac-api-spec repos
 | [Sort](item-search/README.md#sort)                                                | [Item Search](item-search/) request                                                                        | Adds Parameter to control sorting of returns results.                                                                                   | *Pilot*    |
 | [Transaction](ogcapi-features/extensions/transaction/README.md)                   | [STAC - Features API](ogcapi-features) POST on `/items` endpoint, DELETE/PUT on `/items/{itemId}` endpoint | Adds PUT and DELETE endpoints for the creation, editing, and deleting of Item objects.                                         | *Pilot*    |
 | [Items and Collections API Version](ogcapi-features/extensions/version/README.md) | [STAC - Features API](ogcapi-features) on `/items` endpoint                                                | Adds GET versions resource to Collection and Item endpoints and provides semantics for a versioning scheme for Collection and Item objects. | *Proposal* |
-| [Query](item-search/README.md#query) | [Item Search](item-search/) request | Adds parameter to search Item and Collection properties. | *Deprecated* |
+| [Query](item-search/README.md#query) | [Item Search](item-search/) request | Adds parameter to search Item and Collection properties. | *Pilot*, scheduled to be *Deprecated* |
 
 ### Conformance classes of extensions
 

--- a/fragments/query/README.md
+++ b/fragments/query/README.md
@@ -2,8 +2,7 @@
 
 - **OpenAPI specification:** [openapi.yaml](openapi.yaml)
 - **Conformance Class:** <https://api.stacspec.org/v1.0.0-beta.2/item-search#query>
-- **Extension [Maturity Classification](../../extensions.md#extension-maturity):** Deprecated in  
-  favor of the [Filter Extension](../filter/README.md) using [CQL](http://docs.opengeospatial.org/DRAFTS/19-079.html).
+- **Extension [Maturity Classification](../../extensions.md#extension-maturity):** Pilot, scheduled to be Deprecated in favor of the [Filter Extension](../filter/README.md) using [CQL](http://docs.opengeospatial.org/DRAFTS/19-079.html).
 - **Dependents:**
   - [Item Search](../../item-search)
 

--- a/item-search/README.md
+++ b/item-search/README.md
@@ -310,10 +310,10 @@ The full description and examples of this are found in the [context fragment](..
 ### Query
 
 - **Conformance URI:** <https://api.stacspec.org/v1.0.0-beta.2/item-search#query>
-- **Extension [Maturity Classification](../extensions.md#extension-maturity):** Deprecated
+- **Extension [Maturity Classification](../extensions.md#extension-maturity):** Pilot, scheduled to be Deprecated
 - **Definition**: [STAC API - Query Fragment](../fragments/query/)
 
-**Note** - the Query Extension is deprecated as of 1.0.0. Implementers
+**Note** - the Query Extension will possibly be deprecated as of 1.0.0. Implementers
 are encouraged to use the Filter Extension instead.
 
 The STAC search endpoint, `/search`, by default only accepts a limited set of parameters to limit the results

--- a/item-search/README.md
+++ b/item-search/README.md
@@ -313,7 +313,7 @@ The full description and examples of this are found in the [context fragment](..
 - **Extension [Maturity Classification](../extensions.md#extension-maturity):** Pilot, scheduled to be Deprecated
 - **Definition**: [STAC API - Query Fragment](../fragments/query/)
 
-**Note** - the Query Extension will possibly be deprecated as of 1.0.0. Implementers
+**Note** - the Query Extension will be deprecated at some point in 1.x. Implementers
 are encouraged to use the Filter Extension instead.
 
 The STAC search endpoint, `/search`, by default only accepts a limited set of parameters to limit the results


### PR DESCRIPTION
**Related Issue(s):** None


**Proposed Changes:**

1. Change deprecated description
2. Query extension as scheduled to be deprecated

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [x] I will add my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/dev/CHANGELOG.md) when the PR is reviewed
