### PR TITLE
reorganize extensions list to avoid long lines and html

### DIFF
--- a/.circleci/rc.yaml
+++ b/.circleci/rc.yaml
@@ -4,7 +4,7 @@ plugins:
 # Apply some recommended defaults for consistency
   - remark-preset-lint-consistent
   - remark-preset-lint-recommended
-    #  - lint-no-html
+  - lint-no-html
 # General formatting
   - - remark-lint-emphasis-marker
     - '*'

--- a/extensions.md
+++ b/extensions.md
@@ -65,15 +65,24 @@ This is the list of all extensions that are contained in the stac-api-spec repos
 Each extension has its own conformance URI, which is used in the `conformsTo` response of the landing page to let clients know what capabilities 
 the service supports. This are listed at the top of each extension description, but the full table is given here for ease of reference.
 
-| Extension Name | Conformance Class URIs  |
-|---------------|-------------------------|
-| [Fields](item-search/README.md#fields)   | <https://api.stacspec.org/v1.0.0-beta.2/item-search#fields>  |
-| [Filter](item-search/README.md#filter)   | <https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:filter><br/><https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:simple-cql><br/><https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:item-search-filter><br/><https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:cql-text><br/><https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:cql-json> |
-| [Context](item-search/README.md#context) | <https://api.stacspec.org/v1.0.0-beta.2/item-search#context> |
-| [Sort](item-search/README.md#sort)       | <https://api.stacspec.org/v1.0.0-beta.2/item-search#sort>    |
-| [Transaction](ogcapi-features/extensions/transaction/README.md) | <https://api.stacspec.org/v1.0.0-beta.2/ogcapi-features/extensions/transaction> |
-| [Items and Collections API Version](ogcapi-features/extensions/version/README.md) | <https://api.stacspec.org/v1.0.0-beta.2/ogcapi-features/extensions/version> |
-| [Query](item-search/README.md#query)     | <https://api.stacspec.org/v1.0.0-beta.2/item-search#query> |
+- [Fields](item-search/README.md#fields)
+  - <https://api.stacspec.org/v1.0.0-beta.2/item-search#fields>
+- [Filter](item-search/README.md#filter)
+  - <https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:filter>
+  - <https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:simple-cql>
+  - <https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:item-search-filter>
+  - <https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:cql-text>
+  - <https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:cql-json>
+- [Context](item-search/README.md#context)
+  - <https://api.stacspec.org/v1.0.0-beta.2/item-search#context> |
+- [Sort](item-search/README.md#sort)
+  - <https://api.stacspec.org/v1.0.0-beta.2/item-search#sort>    |
+- [Transaction](ogcapi-features/extensions/transaction/README.md)
+  - <https://api.stacspec.org/v1.0.0-beta.2/ogcapi-features/extensions/transaction> |
+- [Items and Collections API Version](ogcapi-features/extensions/version/README.md)
+  - <https://api.stacspec.org/v1.0.0-beta.2/ogcapi-features/extensions/version>
+- [Query](item-search/README.md#query)
+  - <https://api.stacspec.org/v1.0.0-beta.2/item-search#query> |
 
 ## Third-party / vendor extensions
 

--- a/extensions.md
+++ b/extensions.md
@@ -74,15 +74,15 @@ the service supports. This are listed at the top of each extension description, 
   - <https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:cql-text>
   - <https://api.stacspec.org/v1.0.0-beta.2/item-search#filter:cql-json>
 - [Context](item-search/README.md#context)
-  - <https://api.stacspec.org/v1.0.0-beta.2/item-search#context> |
+  - <https://api.stacspec.org/v1.0.0-beta.2/item-search#context>
 - [Sort](item-search/README.md#sort)
-  - <https://api.stacspec.org/v1.0.0-beta.2/item-search#sort>    |
+  - <https://api.stacspec.org/v1.0.0-beta.2/item-search#sort>
 - [Transaction](ogcapi-features/extensions/transaction/README.md)
-  - <https://api.stacspec.org/v1.0.0-beta.2/ogcapi-features/extensions/transaction> |
+  - <https://api.stacspec.org/v1.0.0-beta.2/ogcapi-features/extensions/transaction>
 - [Items and Collections API Version](ogcapi-features/extensions/version/README.md)
   - <https://api.stacspec.org/v1.0.0-beta.2/ogcapi-features/extensions/version>
 - [Query](item-search/README.md#query)
-  - <https://api.stacspec.org/v1.0.0-beta.2/item-search#query> |
+  - <https://api.stacspec.org/v1.0.0-beta.2/item-search#query>
 
 ## Third-party / vendor extensions
 


### PR DESCRIPTION
**Related Issue(s):** #155


**Proposed Changes:**

1. reorganize table of extensions into list to avoid HTML and long lines

**PR Checklist:**

- [X] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [X] This PR has **no** breaking changes.
- [X] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
