### PR TITLE
Remove stac version and extensions from item collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 ### Removed
+- Remove stac_version and stac_extensions fields in ItemCollection
 
 ### Fixed
   

--- a/core/commons.yaml
+++ b/core/commons.yaml
@@ -600,8 +600,8 @@ components:
       example:
         stac_version: 1.0.0
         stac_extensions:
-          - eo
-          - view
+          - 'https://stac-extensions.github.io/eo/v1.0.0/schema.json'
+          - 'https://stac-extensions.github.io/view/v1.0.0/schema.json'
           - 'https://example.com/cs-extension/1.0/schema.json'
         type: Feature
         id: CS3-20160503_132131_05

--- a/fragments/filter/README.md
+++ b/fragments/filter/README.md
@@ -627,9 +627,9 @@ A sample STAC Item (excluding `assets`) is:
   "type": "Feature",
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "eo",
-    "view",
-    "proj"
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
   ],
   "id": "S2A_60HWB_20201111_0_L2A",
   "bbox": [ 176.9997779369264, -39.83783732066656, 178.14624317719924, -38.842842449352425],

--- a/fragments/itemcollection/README.md
+++ b/fragments/itemcollection/README.md
@@ -21,22 +21,9 @@ This object describes a STAC ItemCollection. The fields `type` and `features` ar
 
 | Field Name      | Type                                    | Description |
 | --------------- | --------------------------------------- | ----------- |
-| stac_version    | string                                  | **REQUIRED.** The STAC version the ItemCollection implements. |
-| stac_extensions | \[string\]                                | A list of extensions the ItemCollection implements. |
 | type            | string                                  | **REQUIRED.** Always "FeatureCollection" to provide compatibility with GeoJSON. |
 | features        | [STAC Item](../../stac-spec/item-spec/item-spec.md)               | **REQUIRED** A possibly-empty array of Item objects. |
 | links           | [Link Object](../../stac-spec/item-spec/item-spec.md#link-object) | An array of Links related to this ItemCollection. |
-
-**stac_version**: In general, STAC versions can be mixed, but please keep the [recommended best 
-practices](../../stac-spec/best-practices.md#mixing-stac-versions) in mind.
-
-**stac_extensions**: A list of STAC content extensions the ItemCollection implements. The list contains URLs to the JSON Schema files it 
-can be validated against. For official [STAC extensions](https://stac-extensions.github.io/#list-of-stac-extensions), a "shortcut"
-can be used. This means you can specify the folder name of the extension, for example `single-file-stac` for the Single File 
-STAC extension. This does *not* apply for [API extensions](../../extensions.md). If the versions of the extension and the item diverge, 
-you can specify the URL of the JSON schema file. This list must only contain extensions that extend the ItemCollection itself, see the 
-the 'Scope' column in the list of extensions. It must not contain extensions that extend the Item objects, these must be specified in the 
-Item object directly.
 
 ## Extensions
 

--- a/fragments/itemcollection/examples/itemcollection-sample-full.json
+++ b/fragments/itemcollection/examples/itemcollection-sample-full.json
@@ -1,6 +1,4 @@
 {
-  "stac_version": "1.0.0",
-  "stac_extensions": [],
   "type": "FeatureCollection",
   "features": [
     {

--- a/fragments/itemcollection/examples/itemcollection-sample-minimal.json
+++ b/fragments/itemcollection/examples/itemcollection-sample-minimal.json
@@ -1,6 +1,4 @@
 {
-  "stac_version": "1.0.0",
-  "stac_extensions": [],
   "type": "FeatureCollection",
   "features": []
 }

--- a/fragments/itemcollection/openapi.yaml
+++ b/fragments/itemcollection/openapi.yaml
@@ -11,14 +11,9 @@ components:
         A GeoJSON FeatureCollection augmented with foreign members that contain values relevant to a STAC entity
       type: object
       required:
-        - stac_version
         - features
         - type
       properties:
-        stac_version:
-          $ref: '../../core/commons.yaml#/components/schemas/stac_version'
-        stac_extensions:
-          $ref: '../../core/commons.yaml#/components/schemas/stac_extensions'
         type:
           type: string
           enum:


### PR DESCRIPTION
**Related Issue(s):** #141


**Proposed Changes:**

1. remove ItemCollection fields stac_version and stac_extensions, as they are not STAC entities

**PR Checklist:**

- [X] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [X] This PR has **no** breaking changes.
- [X] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
