### PR TITLE
add clarifying language about using items instead of item

### DIFF
--- a/ogcapi-features/README.md
+++ b/ogcapi-features/README.md
@@ -68,11 +68,14 @@ specified in GeoJSON.
 
 A typical OAFeat will have multiple collections. Simple search for items within a collection can be done
 with the resource endpoint `GET /collections/{collectionId}/items`. This endpoint should be exposed via a 
-link in the Collection with `rel=items`, as shown in the [Example Landing Page diagram](../overview.md#example-landing-page). 
-Unlike static STAC catalogs, it is recommended **not** to use `item` relations, but instead rely on 
+link in the individual collection's endpoint with `rel=items`, as shown in the 
+[Example Landing Page diagram](../overview.md#example-landing-page). Note that this relation is `items`, which is
+distinct from the `item` relation defined in STAC for linking to a single Item. Most APIs will not use 
+`item` relations directly, but instead rely on 
 the collection resource linking to a paginated endpoint returning items through a link relation 
 `items`, e.g., `/collections/{collectionId}` has a link with relation `items` linking 
-to `/collections/{collectionId}/items`.  
+to `/collections/{collectionId}/items`. However, static catalogs and APIs can be exposed via the same 
+endpoints, so APIs may contain `item` relations.
 
 It is recommended to have each OAFeat Collection correspond to a STAC Collection,
 and the `/collections/{collectionId}/items` endpoint can be used as a single collection search. Implementations may **optionally** 

--- a/ogcapi-features/README.md
+++ b/ogcapi-features/README.md
@@ -97,7 +97,7 @@ distinct from the `item` relation defined in STAC for linking to a single Item. 
 the collection resource linking to a paginated endpoint returning items through a link relation 
 `items`, e.g., `/collections/{collectionId}` has a link with relation `items` linking 
 to `/collections/{collectionId}/items`. However, static catalogs and other parts of the API can be combined 
-endpoints, so APIs may contain `item` relations.
+so that APIs that do not implement OAFeat may contain `item` relations.
 
 It is recommended to have each OAFeat Collection correspond to a STAC Collection,
 and the `/collections/{collectionId}/items` endpoint can be used as a single collection search. Implementations may **optionally** 

--- a/ogcapi-features/README.md
+++ b/ogcapi-features/README.md
@@ -96,8 +96,7 @@ distinct from the `item` relation defined in STAC for linking to a single Item. 
 `item` relations directly, but instead rely on 
 the collection resource linking to a paginated endpoint returning items through a link relation 
 `items`, e.g., `/collections/{collectionId}` has a link with relation `items` linking 
-to `/collections/{collectionId}/items`. However, static catalogs and other parts of the API can be combined 
-so that APIs that do not implement OAFeat may contain `item` relations.
+to `/collections/{collectionId}/items`. However, static catalogs and other parts of the API may contain `item` relations.
 
 It is recommended to have each OAFeat Collection correspond to a STAC Collection,
 and the `/collections/{collectionId}/items` endpoint can be used as a single collection search. Implementations may **optionally** 

--- a/ogcapi-features/README.md
+++ b/ogcapi-features/README.md
@@ -4,6 +4,7 @@
   - [Endpoints](#endpoints)
   - [Examples](#examples)
   - [Example Landing Page for STAC API - Features](#example-landing-page-for-stac-api---features)
+  - [Example Collection for STAC API - Features](#example-collection-for-stac-api---features)
 
 *based on [**OGC API - Features - Part 1: Core**](https://www.ogc.org/standards/ogcapi-features)*
 
@@ -43,7 +44,7 @@ The core OGC API - Features endpoints are shown below, with details provided in 
 | `/collections/{collectionId}/items/{featureId}` | [Item](../stac-spec/item-spec/README.md)                | Returns single Item (GeoJSON Feature)                                                                                                      |
 | `/api`                                          | OpenAPI 3.0 JSON                                        | Returns an OpenAPI description of the service from the `service-desc` link `rel` - not required to be `/api`, but the document is required |
 
-The OGC API - Features is a standard API that represents collections of geospatial data. It defines the RESTful interface 
+The OGC API - Features is a standard API that represents collections of geospatial data. It defines a RESTful interface 
 to query geospatial data, with GeoJSON as a main return type. With OAFeat you can return any `Feature`, which is a geometry 
 plus any number of properties. The core [STAC Item spec](../stac-spec/item-spec/README.md) 
 enhances the core `Feature` with additional requirements and options to enable cataloging of spatiotemporal 'assets' like 
@@ -65,8 +66,15 @@ In OAFeat, Features are the individual records within a Collection and are usual
 is outside the scope of STAC API, as the [STAC Item](../stac-spec/item-spec/item-spec.md) is
 specified in GeoJSON.
 
-A typical OAFeat will have multiple collections, and each will just offer simple search for its particular collection at 
-`GET /collections/{collectionId}/items`. It is recommended to have each OAFeat Collection correspond to a STAC Collection,
+A typical OAFeat will have multiple collections. Simple search for items within a collection can be done
+with the resource endpoint `GET /collections/{collectionId}/items`. This endpoint should be exposed via a 
+link in the Collection with `rel=items`, as shown in the [Example Landing Page diagram](../overview.md#example-landing-page). 
+Unlike static STAC catalogs, it is recommended **not** to use `item` relations, but instead rely on 
+the collection resource linking to a paginated endpoint returning items through a link relation 
+`items`, e.g., `/collections/{collectionId}` has a link with relation `items` linking 
+to `/collections/{collectionId}/items`.  
+
+It is recommended to have each OAFeat Collection correspond to a STAC Collection,
 and the `/collections/{collectionId}/items` endpoint can be used as a single collection search. Implementations may **optionally** 
 provide support for the full superset of STAC API query parameters to the `/collections/{collectionId}/items` endpoint,
 where the collection ID in the path is equivalent to providing that single value in the `collections` query parameter in 
@@ -157,5 +165,43 @@ the [overview](../overview.md#example-landing-page) document.
             "href": "https://stacserver.org/collections"
         }
     ]
+}
+```
+
+## Example Collection for STAC API - Features
+
+The landing page `data` relation points to an endpoint to retrieve all collections. Each collection then has
+a link relation to its `items` resource through the link with a rel value `items`.  Note here that, unlike 
+as is typical with a static STAC Collection, there are no links here with rel value `item`. 
+
+`https://stacserver.org/collections/aster-l1t`
+
+```
+{
+  "id": "aster-l1t",
+  "type": "Collection",
+  "title": "ASTER L1T",
+  "links": [
+    {
+      "rel": "items",
+      "type": "application/geo+json",
+      "href": "https://stacserver.org/collections/aster-l1t/items"
+    },
+    {
+      "rel": "parent",
+      "type": "application/json",
+      "href": "https://stacserver.org"
+    },
+    {
+      "rel": "root",
+      "type": "application/json",
+      "href": "https://stacserver.org"
+    },
+    {
+      "rel": "self",
+      "type": "application/json",
+      "href": "https://stacserver.org/collections/aster-l1t"
+    }
+  ]
 }
 ```

--- a/ogcapi-features/README.md
+++ b/ogcapi-features/README.md
@@ -92,7 +92,7 @@ A typical OAFeat will have multiple collections. Simple search for items within 
 with the resource endpoint `GET /collections/{collectionId}/items`. This endpoint should be exposed via a 
 link in the individual collection's endpoint with `rel=items`, as shown in the 
 [Example Landing Page diagram](../overview.md#example-landing-page). Note that this relation is `items`, which is
-distinct from the `item` relation defined in STAC for linking to a single Item. Most APIs will not use 
+distinct from the `item` relation defined in STAC for linking to a single Item. The part of the API implementing OAFeat will usually not use 
 `item` relations directly, but instead rely on 
 the collection resource linking to a paginated endpoint returning items through a link relation 
 `items`, e.g., `/collections/{collectionId}` has a link with relation `items` linking 

--- a/ogcapi-features/README.md
+++ b/ogcapi-features/README.md
@@ -96,7 +96,7 @@ distinct from the `item` relation defined in STAC for linking to a single Item. 
 `item` relations directly, but instead rely on 
 the collection resource linking to a paginated endpoint returning items through a link relation 
 `items`, e.g., `/collections/{collectionId}` has a link with relation `items` linking 
-to `/collections/{collectionId}/items`. However, static catalogs and APIs can be exposed via the same 
+to `/collections/{collectionId}/items`. However, static catalogs and other parts of the API can be combined 
 endpoints, so APIs may contain `item` relations.
 
 It is recommended to have each OAFeat Collection correspond to a STAC Collection,

--- a/overview.md
+++ b/overview.md
@@ -99,7 +99,7 @@ column is more of an example in some cases. OGC API makes some endpoint location
 | `/api`                                              | [OAFeat](ogcapi-features)  | service-desc      | OpenAPI 3.0 JSON                                  | The OpenAPI definition of the endpoints in this service                                                                             |
 | **`/collections/{collectionId}`**                   | [OAFeat](ogcapi-features)  | collection        | Collection                                        | Returns single Collection JSON                                                                                                      |
 | **`/collections/{collectionId}/items`**             | [OAFeat](ogcapi-features)  | items             | ItemCollection                                    | GeoJSON FeatureCollection-conformant entity of Item objects in collection                                                                  |
-| **`/collections/{collectionId}/items/{featureId}`** | [OAFeat](ogcapi-features)  | Item              | Returns single Item (GeoJSON Feature)             |                                                                                                                                     |
+| **`/collections/{collectionId}/items/{featureId}`** | [OAFeat](ogcapi-features)  | item              | Returns single Item (GeoJSON Feature). This relation is defined by STAC, but its use is discouraged in STAC API, as Items should be referenced through their containing Collection rather than directly.            |                                                                                                                                     |
 
 ## Conformance Classes
 

--- a/overview.md
+++ b/overview.md
@@ -99,7 +99,7 @@ column is more of an example in some cases. OGC API makes some endpoint location
 | `/api`                                              | [OAFeat](ogcapi-features)  | service-desc      | OpenAPI 3.0 JSON                                  | The OpenAPI definition of the endpoints in this service                                                                             |
 | **`/collections/{collectionId}`**                   | [OAFeat](ogcapi-features)  | collection        | Collection                                        | Returns single Collection JSON                                                                                                      |
 | **`/collections/{collectionId}/items`**             | [OAFeat](ogcapi-features)  | items             | ItemCollection                                    | GeoJSON FeatureCollection-conformant entity of Item objects in collection                                                                  |
-| **`/collections/{collectionId}/items/{featureId}`** | [OAFeat](ogcapi-features)  | item              | Returns single Item (GeoJSON Feature). This relation is most commonly used in static STAC catalogs.  In STAC API, Items are typically referenced through their containing Collection. |
+| **`/collections/{collectionId}/items/{featureId}`** | [OAFeat](ogcapi-features)  | item              | Returns single Item (GeoJSON Feature). This relation is most commonly used in static STAC catalogs. |
 
 ## Conformance Classes
 

--- a/overview.md
+++ b/overview.md
@@ -99,7 +99,7 @@ column is more of an example in some cases. OGC API makes some endpoint location
 | `/api`                                              | [OAFeat](ogcapi-features)  | service-desc      | OpenAPI 3.0 JSON                                  | The OpenAPI definition of the endpoints in this service                                                                             |
 | **`/collections/{collectionId}`**                   | [OAFeat](ogcapi-features)  | collection        | Collection                                        | Returns single Collection JSON                                                                                                      |
 | **`/collections/{collectionId}/items`**             | [OAFeat](ogcapi-features)  | items             | ItemCollection                                    | GeoJSON FeatureCollection-conformant entity of Item objects in collection                                                                  |
-| **`/collections/{collectionId}/items/{featureId}`** | [OAFeat](ogcapi-features)  | item              | Returns single Item (GeoJSON Feature). This relation is most commonly used in static STAC catalogs. |
+| **`/collections/{collectionId}/items/{featureId}`** | [OAFeat](ogcapi-features)  | item              | Returns single Item (GeoJSON Feature). This relation is usually not used in OAFeat implementations. |
 
 ## Conformance Classes
 

--- a/overview.md
+++ b/overview.md
@@ -99,7 +99,7 @@ column is more of an example in some cases. OGC API makes some endpoint location
 | `/api`                                              | [OAFeat](ogcapi-features)  | service-desc      | OpenAPI 3.0 JSON                                  | The OpenAPI definition of the endpoints in this service                                                                             |
 | **`/collections/{collectionId}`**                   | [OAFeat](ogcapi-features)  | collection        | Collection                                        | Returns single Collection JSON                                                                                                      |
 | **`/collections/{collectionId}/items`**             | [OAFeat](ogcapi-features)  | items             | ItemCollection                                    | GeoJSON FeatureCollection-conformant entity of Item objects in collection                                                                  |
-| **`/collections/{collectionId}/items/{featureId}`** | [OAFeat](ogcapi-features)  | item              | Returns single Item (GeoJSON Feature). This relation is defined by STAC, but its use is discouraged in STAC API, as Items should be referenced through their containing Collection rather than directly.            |                                                                                                                                     |
+| **`/collections/{collectionId}/items/{featureId}`** | [OAFeat](ogcapi-features)  | item              | Returns single Item (GeoJSON Feature). This relation is most commonly used in static STAC catalogs.  In STAC API, Items are typically referenced through their containing Collection. |
 
 ## Conformance Classes
 


### PR DESCRIPTION
**Related Issue(s):** #161


**Proposed Changes:**

1. Add clarifying language about using link relation `items` instead of `item` 

**PR Checklist:**

- [X] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [X] This PR has **no** breaking changes.
- [X] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
