### PR TITLE
clarify 3d bbox query over 2d geometry

### DIFF
--- a/item-search/README.md
+++ b/item-search/README.md
@@ -97,8 +97,14 @@ The core parameters for STAC search are defined by OAFeat, and STAC adds a few p
 Only one of either **intersects** or **bbox** should be specified.  If both are specified, a 400 Bad Request response 
 should be returned. See [examples](examples.md) to see sample requests.
 
-**bbox** Represented using either 2D or 3D geometries. The length of the array must be 2\*n where n is the number of dimensions. The array contains all axes of the southwesterly most extent followed by all axes of the northeasterly most extent specified in Longitude/Latitude or Longitude/Latitude/Elevation based on [WGS 84](http://www.opengis.net/def/crs/OGC/1.3/CRS84). When using 3D geometries, the elevation of the southwesterly most extent is the minimum elevation in meters and the elevation of the northeasterly most extent is the maximum.  
-
+**bbox** Represented using either 2D or 3D geometries. The length of the array must be 2\*n where 
+*n* is the number of dimensions. The array contains all axes of the southwesterly most extent 
+followed by all axes of the northeasterly most extent specified in Longitude/Latitude or 
+Longitude/Latitude/Elevation based on [WGS 84](http://www.opengis.net/def/crs/OGC/1.3/CRS84). 
+When using 3D geometries, the elevation of the southwesterly most extent is the minimum elevation 
+in meters and the elevation of the northeasterly most extent is the maximum. When filtering with 
+a 3D bbox over Items with 2D geometries, it is assumed that the 2D geometries are at 
+elevation 0.
 
 ## Response
 


### PR DESCRIPTION
**Related Issue(s):** #160 


**Proposed Changes:**

1. clarify 3d bbox query over Item with 2d bbox means Item is at elevation 0

**PR Checklist:**

- [X] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [X] This PR has **no** breaking changes.
- [X] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
