### PR TITLE
fix filter queryables definition to at least have a content type and object

### DIFF
--- a/fragments/filter/openapi.yaml
+++ b/fragments/filter/openapi.yaml
@@ -31,11 +31,7 @@ paths:
       # todo: may have collections parameter in the future
       responses:
         '200':
-          description: A JSON Schema defining the Queryables allowed in CQL expressions
-          # content:
-          #   application/schema+json:
-          #     schema:
-          #       $ref: 'https://json-schema.org/draft/2019-09/schema'
+          $ref: '#/components/responses/Queryables'
         default:
           $ref: '../../core/commons.yaml#/components/responses/Error'
   /collections/{collectionId}:
@@ -74,11 +70,7 @@ paths:
         - Queryables
       responses:
         '200':
-          description: A JSON Schema defining the Queryables allowed in CQL expressions filtering only that collection
-          # content:
-          #   application/schema+json:
-          #     schema:
-          #       $ref: 'https://json-schema.org/draft/2019-09/schema'
+          $ref: '#/components/responses/Queryables'
         default:
           $ref: '../../core/commons.yaml#/components/responses/Error'
 components:
@@ -153,3 +145,10 @@ components:
         accept is 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'.
       type: string
       format: uri
+  responses:
+    Queryables:
+      description: A JSON Schema defining the Queryables allowed in CQL expressions
+      content:
+        application/schema+json:
+          schema:
+            type: object

--- a/fragments/filter/openapi.yaml
+++ b/fragments/filter/openapi.yaml
@@ -4,10 +4,22 @@ info:
   description: Adds parameters to compare properties and only return the items that match
   version: 1.0.0-beta.2
 
+tags:
+  - name: STAC API - Core
+    description: Part of STAC API - Core definition
+  - name: STAC API - Features
+    description: Part of STAC API - Features definition
+  - name: STAC API - Collections
+    description: Part of STAC API - Collections definition
+  - name: STAC API - Filter Extension
+    description: Part of STAC API - Filter extension definition
+
 paths:
   '/':
-    description: Landing Page
     get:
+      description: Landing Page
+      tags:
+        - STAC API - Core
       responses:
         '200':
           description: Landing Page
@@ -26,7 +38,7 @@ paths:
         precise definition of this can be found in the OGC API - Features - Part 3: Filtering and the 
         Common Query Language (CQL) specification.
       tags:
-        - Queryables
+        - STAC API - Filter Extension
       # parameters:
       # todo: may have collections parameter in the future
       responses:
@@ -36,6 +48,11 @@ paths:
           $ref: '../../core/commons.yaml#/components/responses/Error'
   /collections/{collectionId}:
     get:
+      description: |-
+        This endpoint returns a list of Collections.
+      tags:
+        - STAC API - Features
+        - STAC API - Collections
       parameters:
         - in: path
           name: collectionId
@@ -67,7 +84,7 @@ paths:
           required: true
           description: ID of Collection
       tags:
-        - Queryables
+        - STAC API - Filter Extension
       responses:
         '200':
           $ref: '#/components/responses/Queryables'


### PR DESCRIPTION
**Related Issue(s):** #156


**Proposed Changes:**

1. fix queryables definition in Filter to at least have a content type and object. In the future, we should have a precise definition for JSON Schema, but this is quite a bit of work to write. 

**PR Checklist:**

- [X] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [X] This PR has **no** breaking changes.
- [X] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
