### PR TITLE
rename Queryable First Operand to Queryable Second Operand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added STAC API - Collections definition (subset of STAC API - Features)
+- More thorough definitions for valid `datetime` and `bbox` query parameter values.
 
 ### Changed
 - Query extension not deprecated; recommendation to use Filter (https://github.com/radiantearth/stac-api-spec/pull/157)
 - Filter Extension conformance classes refactored to better align with STAC API use cases.
+- Renamed conformance class "Queryable First Operand" 
+  (https://api.stacspec.org/v1.0.0-beta.3/item-search#filter:queryable-first-operand) to 
+  "Queryable Second Operand" 
+  (https://api.stacspec.org/v1.0.0-beta.3/item-search#filter:queryable-second-operand)
 
 ### Deprecated
 

--- a/fragments/filter/README.md
+++ b/fragments/filter/README.md
@@ -15,7 +15,7 @@
   - Functions: <https://api.stacspec.org/v1.0.0-beta.3/item-search#filter:functions>
   - Arithmetic: <https://api.stacspec.org/v1.0.0-beta.3/item-search#filter:arithmetic>
   - Arrays: <https://api.stacspec.org/v1.0.0-beta.3/item-search#filter:arrays>
-  - Queryable First Operand: <https://api.stacspec.org/v1.0.0-beta.3/item-search#filter:queryable-first-operand>
+  - Queryable Second Operand: <https://api.stacspec.org/v1.0.0-beta.3/item-search#filter:queryable-second-operand>
 - **Extension [Maturity Classification](../../extensions.md#extension-maturity):** Pilot
 - **Dependents:**
   - [Item Search](../../item-search)
@@ -180,7 +180,7 @@ URI should follow the same pattern relative to OAFeat CQL.
 - Functions (`https://api.stacspec.org/v1.0.0-beta.3/item-search#filter:functions`) defines the same operators as OAF Part 3 CQL Functions.
 - Arithmetic: (`https://api.stacspec.org/v1.0.0-beta.3/item-search#filter:arithmetic`) defines the same operators as OAF Part 3 CQL Arithmetic.
 - Arrays: (`https://api.stacspec.org/v1.0.0-beta.3/item-search#filter:arrays`) defines the same operators as OAF Part 3 CQL Arrays.
-- Queryable Operands: (`https://api.stacspec.org/v1.0.0-beta.3/item-search#filter:queryable-operands`) allows the 
+- Queryable Second Operand: (`https://api.stacspec.org/v1.0.0-beta.3/item-search#filter:queryable-second-operand`) allows the 
   use of queryables (e.g., properties) in any position of a clause, not just in the first position. This allows 
   predicates like `property1 == property2` be expressed, whereas the Basic CQL conformance class only requires
   comparisons against literal values.


### PR DESCRIPTION
**Related Issue(s):** none


**Proposed Changes:**

1. Filter Extension conformance class Queryable First Operand is mistakenly named, as this class actually allows the **second** operand to be queryable. Renamed appropriately. 

**PR Checklist:**

- [X] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [X] This PR has **no** breaking changes.
- [X] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
