### PR TITLE
Shall and endpoint table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The required Link Relations and endpoints for each conformance class now use the wording of 'shall' 
+  instead of 'should'. While this technically changes the semantics, it was generally understood 
+  previously the semantics were those of 'shall' (must).
+
 ### Deprecated
 
 ### Removed

--- a/collections/README.md
+++ b/collections/README.md
@@ -1,10 +1,10 @@
 # STAC API - Collections
 
 - [STAC API - Collections](#stac-api---collections)
-  - [Link Relations](#link-relations)
-  - [Endpoints](#endpoints)
-  - [Example](#example)
-  - [Conformance](#conformance)
+	- [Link Relations](#link-relations)
+	- [Endpoints](#endpoints)
+	- [Example](#example)
+	- [Conformance](#conformance)
 
 - **OpenAPI specification:** Missing
 - **Conformance URI:** <http://stacspec.org/spec/api/1.0.0-beta.3/extensions/collections>
@@ -23,21 +23,24 @@ aim to align with it. But it still seems to be in flux.*
 
 ## Link Relations
 
-The following Link relations should exist in the Landing Page (root).
+The following Link relations shall exist in the Landing Page (root).
 
 | **rel**        | **href**             | **From**       | **Description**                                                                                                                                                         |
 | -------------- | -------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `root`         | `/`                  | STAC Core      | The root URI                                                                                                                                                            |
 | `self`         | `/`                  | OAFeat         | Self reference, same as root URI                                                                                                                                        |
 | `service-desc` | `/api` (recommended) | OAFeat OpenAPI | The OpenAPI service description. Uses the `application/vnd.oai.openapi+json;version=3.0` media type to refer to the OpenAPI 3.0 document that defines the service's API |
-| `child`        | various              | STAC Core      | The child STAC Catalogs & Collections. Provides curated paths to get to STAC Collection and Item objects                                                                |
 | `data`         | `/collections`       | OAFeat         | List of Collections                                                                                                                                                     |
-
-Additionally, a `service-doc` endpoint is recommended.
-
+A `service-doc` endpoint is recommended, but not required.
 | **rel**       | **href**                  | **From**       | **Description**                                                                                                         |
 | ------------- | ------------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `service-doc` | `/api.html` (recommended) | OAFeat OpenAPI | An HTML service description.  Uses the `text/html` media type to refer to a human-consumable description of the service |
+
+Additionally, `child` relations may exist to individual catalogs and collections.
+| **rel**        | **href**             | **From**       | **Description**                                                                                                                                                         |
+| -------------- | -------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+
+| `child`        | various              | STAC Core      | The child STAC Catalogs & Collections. Provides curated paths to get to STAC Collection and Item objects                                                                |
 
 The following Link relations should exist in the `/collections` endpoint response.
 

--- a/core/README.md
+++ b/core/README.md
@@ -48,20 +48,24 @@ API endpoints from OAFeat or STAC API to be implemented, so the following links 
 
 ## Link Relations
 
-The following Link relations should exist in the Landing Page (root).
+The following Link relations shall exist in the Landing Page (root).
 
 | **rel**        | **href**             | **From**       | **Description**                                                                                                                                                         |
 | -------------- | -------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `root`         | `/`                  | STAC Core      | The root URI                                                                                                                                                            |
 | `self`         | `/`                  | OAFeat         | Self reference, same as root URI                                                                                                                                        |
 | `service-desc` | `/api` (recommended) | OAFeat OpenAPI | The OpenAPI service description. Uses the `application/vnd.oai.openapi+json;version=3.0` media type to refer to the OpenAPI 3.0 document that defines the service's API |
-| `child`        | various              | STAC Core      | The child STAC Catalogs & Collections. Provides curated paths to get to STAC Collection and Item objects                                                                |
 
-Additionally, a `service-doc` endpoint is recommended.
-
+A `service-doc` endpoint is recommended, but not required.
 | **rel**       | **href**                  | **From**       | **Description**                                                                                                         |
 | ------------- | ------------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `service-doc` | `/api.html` (recommended) | OAFeat OpenAPI | An HTML service description.  Uses the `text/html` media type to refer to a human-consumable description of the service |
+
+Additionally, `child` relations may exist to individual catalogs and collections.
+| **rel**        | **href**             | **From**       | **Description**                                                                                                                                                         |
+| -------------- | -------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `child`        | various              | STAC Core      | The child STAC Catalogs & Collections. Provides curated paths to get to STAC Collection and Item objects |
+
 
 It is also valid to have `item` links from the landing page, but most STAC API services are used to 
 serve up a large number of features, so they typically

--- a/extensions.md
+++ b/extensions.md
@@ -99,7 +99,7 @@ Please contact a STAC maintainer or open a Pull Request to add your extension to
 ## Creating new extensions
 
 Creating new extensions requires creating an OpenAPI fragment to define it, along with a README markdown file that gives 
-an overview of the functionality. In the README a conformance URI should be provided, so clients can use it to tell if
+an overview of the functionality. In the README, a conformance URI should be provided, so clients can use it to tell if
 a service has the indicated functionality. It is also recommended to note the 'extension maturity', as defined above,
 so others can know how widely it is used.
 

--- a/item-search/README.md
+++ b/item-search/README.md
@@ -44,7 +44,7 @@ Implementing `GET /search` is **required**, `POST /search` is optional, but reco
 
 ## Link Relations
 
-The following Link relations should exist in the Landing Page (root).
+The following Link relations shall exist in the Landing Page (root).
 
 | **rel**        | **href**             | **From**         | **Description**                                                                                                                                                         |
 | -------------- | -------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -53,7 +53,7 @@ The following Link relations should exist in the Landing Page (root).
 | `service-desc` | `/api` (recommended) | OAFeat OpenAPI   | The OpenAPI service description. Uses the `application/vnd.oai.openapi+json;version=3.0` media type to refer to the OpenAPI 3.0 document that defines the service's API |
 | search         | `/search`            | STAC Item Search | URI for the Search endpoint                                                                                                                                             |
 
-Additionally, a `service-doc` endpoint is recommended.
+A `service-doc` endpoint is recommended, but not required.
 
 | **rel**       | **href**                  | **From**       | **Description**                                                                                                         |
 | ------------- | ------------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------- |

--- a/ogcapi-features/README.md
+++ b/ogcapi-features/README.md
@@ -35,7 +35,7 @@ with OAFeat clients. But specialized STAC clients will likely display results be
 
 ## Link Relations
 
-The following Link relations should exist in the Landing Page (root).
+The following Link relations shall exist in the Landing Page (root).
 
 | **rel**        | **href**             | **From**       | **Description**                                                                                                                                                         |
 | -------------- | -------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -45,7 +45,7 @@ The following Link relations should exist in the Landing Page (root).
 | `service-desc` | `/api` (recommended) | OAFeat OpenAPI | The OpenAPI service description. Uses the `application/vnd.oai.openapi+json;version=3.0` media type to refer to the OpenAPI 3.0 document that defines the service's API |
 | `data`         | `/collections`       | OAFeat         | List of Collections                                                                                                                                                     |
 
-Additionally, a `service-doc` endpoint is recommended.
+Additionally, a `service-doc` endpoint is recommended, but not required.
 
 | **rel**       | **href**                  | **From**       | **Description**                                                                                                         |
 | ------------- | ------------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
…implemented for each conformance class

**Related Issue(s):** #195 


**Proposed Changes:**

1. change wording of required endpoints for each conformance class from "should" to "shall".

Technically this is a breaking change, but it was understood before that these were required, we just used the wrong word in the spec.

**PR Checklist:**

- [X] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [ ] ??? This PR has **no** breaking changes.
- [X] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
