### PR TITLE
Missing types

### DIFF
--- a/collections/README.md
+++ b/collections/README.md
@@ -76,6 +76,7 @@ of an array of all STAC Collections and an array of Links.
 			"id": "cool-data",
 			"title": "Cool Data from X Satellite",
 			"description": "A lot of awesome words describing the data",
+			"type": "Collection",
 			"license": "CC-BY",
 			"extent": {
 				"spatial": {

--- a/core/README.md
+++ b/core/README.md
@@ -81,6 +81,7 @@ the [overview](../overview.md#example-landing-page) document.
     "id": "example-stac",
     "title": "A simple STAC API Example",
     "description": "This Catalog aims to demonstrate the a simple landing page",
+    "type": "Catalog",
     "conformsTo" : [
         "https://api.stacspec.org/v1.0.0-beta.4/core"
     ],

--- a/fragments/filter/README.md
+++ b/fragments/filter/README.md
@@ -384,6 +384,7 @@ at least these values:
   ],
   "stac_extensions": [],
   "stac_version": "1.0.0",
+  "type": "Catalog",
 }
 ```
 

--- a/item-search/README.md
+++ b/item-search/README.md
@@ -255,6 +255,7 @@ the [overview](../overview.md#example-landing-page) document.
     "id": "example-stac",
     "title": "A simple STAC API Example",
     "description": "This Catalog aims to demonstrate the a simple landing page",
+    "type": "Catalog",
     "conformsTo" : [
         "https://api.stacspec.org/v1.0.0-beta.4/core",
         "https://api.stacspec.org/v1.0.0-beta.4/item-search"

--- a/ogcapi-features/README.md
+++ b/ogcapi-features/README.md
@@ -150,6 +150,7 @@ the [overview](../overview.md#example-landing-page) document.
     "id": "example-stac",
     "title": "A simple STAC API Example",
     "description": "This Catalog aims to demonstrate the a simple landing page",
+    "type": "Catalog",
     "conformsTo" : [
         "https://api.stacspec.org/v1.0.0-beta.4/core",
         "https://api.stacspec.org/v1.0.0-beta.4/ogcapi-features",

--- a/ogcapi-features/extensions/version/README.md
+++ b/ogcapi-features/extensions/version/README.md
@@ -65,6 +65,7 @@ Request to `GET /collections/my_collection/items/this_is_my_id`:
 ```json
 {
     "id": "this_is_my_id",
+    "type": "Feature",
     "bbox": [],
     "geometry": {},
     "properties": {},
@@ -97,6 +98,7 @@ Request to `GET /collections/my_collection/items/this_is_my_id/versions/02`:
 ```json
 {
     "id": "this_is_my_id",
+    "type": "Feature",
     "bbox": [],
     "geometry": {},
     "properties": {},
@@ -129,6 +131,7 @@ Request to `GET /collections/my_collection/items/this_is_my_id/versions/01`:
 ```json
 {
     "id": "this_is_my_id",
+    "type": "Feature",
     "bbox": [],
     "geometry": {},
     "properties": {},

--- a/overview.md
+++ b/overview.md
@@ -161,6 +161,7 @@ The Landing Page will at least have the following `conformsTo` and `links`:
     "id": "example-stac",
     "title": "A simple STAC API Example",
     "description": "This Catalog aims to demonstrate the a simple landing page",
+    "type": "Catalog",
     "conformsTo" : [
         "https://api.stacspec.org/v1.0.0-beta.4/core",
         "https://api.stacspec.org/v1.0.0-beta.4/item-search",


### PR DESCRIPTION
**Related Issue(s):** #206

[question on gitter.im](https://gitter.im/SpatioTemporal-Asset-Catalog/Lobby?at=612fa59c8065e87a8ebd2659)

**Proposed Changes:**

1. Add missing `"type": "Catalog"`, `"type": "Collection"` or  `"type": "Feature"` for some examples when it was lacking

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [x] ~I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/dev/CHANGELOG.md) **or**~ a CHANGELOG entry is not required.
