### PR TITLE
In all extension openapi specs, change 'Optional Extension' to 'Extension'

### DIFF
--- a/fragments/context/openapi.yaml
+++ b/fragments/context/openapi.yaml
@@ -9,7 +9,7 @@ components:
     itemCollection:
       type: object
       description: |-
-        **Optional Extension:** Context
+        **Extension:** Context
 
         Augments lists of resources with the number of returned and matches resource and the given limit for the request.
       x-stac-api-fragment: context

--- a/fragments/fields/openapi.yaml
+++ b/fragments/fields/openapi.yaml
@@ -11,7 +11,7 @@ components:
       x-stac-api-fragment: fields
       in: query
       description: |-
-        **Optional Extension:** Fields
+        **Extension:** Fields
 
         Determines the shape of the features in the response
       required: false
@@ -25,7 +25,7 @@ components:
       type: object
       x-stac-api-fragment: fields
       description: |-
-        **Optional Extension:** Fields
+        **Extension:** Fields
 
         Determines the shape of the features in the response
       properties:

--- a/fragments/filter/openapi.yaml
+++ b/fragments/filter/openapi.yaml
@@ -133,7 +133,7 @@ components:
       type: object
       x-stac-api-fragment: filter
       description: |-
-        **Optional Extension:** Filter
+        **Extension:** Filter
 
         A filter for properties in Items.
       properties:

--- a/fragments/query/openapi.yaml
+++ b/fragments/query/openapi.yaml
@@ -11,7 +11,7 @@ components:
       x-stac-api-fragment: query
       in: query
       description: |-
-        **Optional Extension:** Query
+        **Extension:** Query
 
         Query for properties in items.
         Use the JSON form of the query used in POST.
@@ -23,7 +23,7 @@ components:
       type: object
       x-stac-api-fragment: query
       description: |-
-        **Optional Extension:** Query
+        **Extension:** Query
 
         Allows users to query properties for specific values
       properties:

--- a/fragments/sort/openapi.yaml
+++ b/fragments/sort/openapi.yaml
@@ -11,7 +11,7 @@ components:
       x-stac-api-fragment: sort
       in: query
       description: |-
-        **Optional Extension:** Sort
+        **Extension:** Sort
 
         An array of property names, prefixed by either "+" for ascending or
         "-" for descending. If no prefix is provided, "+" is assumed.
@@ -26,7 +26,7 @@ components:
       type: object
       x-stac-api-fragment: sort
       description: |-
-        **Optional Extension:** Sort
+        **Extension:** Sort
 
         Sort the results.
       properties:


### PR DESCRIPTION
**Related Issue(s):** #203


**Proposed Changes:**

1. change use of "Optional Extension" to "Extension" in all open api specs. Extensions are optional by default, so the previous wording was redundant.

**PR Checklist:**

- [X] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [X] This PR has **no** breaking changes.
- [X] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
