### PR TITLE
fix: Item defined 'properties' as a required field, but didn't includ…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- definition of Item object was missing `properties` as an attribute
+
 ## [v1.0.0-beta.4] - 2020-10-05
 
 ### Added

--- a/core/commons.yaml
+++ b/core/commons.yaml
@@ -593,6 +593,8 @@ components:
           $ref: '#/components/schemas/itemType'
         links:
           $ref: '#/components/schemas/links'
+        properties:
+          $ref: '#/components/schemas/properties'
         assets:
           $ref: '#/components/schemas/assets'
       example:
@@ -669,7 +671,7 @@ components:
       type: object
       required:
         - datetime
-      description: provides the core metatdata fields plus extensions
+      description: provides the core metadata fields plus extensions
       properties:
         datetime:
           $ref: '#/components/schemas/datetime'


### PR DESCRIPTION
**Related Issue(s):** # n/a


**Proposed Changes:**

1. add missing `properties` properties entry to Item. It was defined as a required field, but not actually in the properties definition.

**PR Checklist:**

- [X] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [X] This PR has **no** breaking changes.
- [X] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
