### PR TITLE
Fix filter ex interval and timestamp examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Filter Extension - examples of using intervals and timestamps in CQL2 were incorrect and have been fixed
+
 ## [v1.0.0-beta.3] - 2020-08-06
 
 ### Added

--- a/fragments/filter/README.md
+++ b/fragments/filter/README.md
@@ -148,8 +148,8 @@ The implementation **must** support these conformance classes:
   parameters `filter-lang`, `filter-crs`, and `filter`.
 - Basic CQL2 (`http://www.opengis.net/spec/cql2/1.0/conf/basic-cql2`) defines the basic operations allowed in 
   the query language used for the `filter` parameter defined by Filter. This includes logical operators (`AND`, `OR`, `NOT`), 
-  comparison operators (`=`, `<>`, `<`, `<=`, `>`, `>=`), and `IS NULL`. The comparison operators are allowed against string, numeric, boolean,
-  and datetime types.
+  comparison operators (`=`, `<>`, `<`, `<=`, `>`, `>=`), and `IS NULL`. The comparison operators are allowed against
+  string, numeric, boolean, date, and datetime types.
 - Item Search Filter (`https://api.stacspec.org/v1.0.0-beta.5/item-search#filter:item-search-filter`) binds the Filter and 
   Basic CQL2 conformance classes to apply to the Item Search endpoint (`/search`).  This class is the correlate of the OAFeat CQL2 Features 
   Filter class that binds Filter and Basic CQL2 to the Features resource (`/collections/{cid}/items`).
@@ -512,8 +512,8 @@ OGC API Features filters only operate against a single collection already.
 filter=collection = 'landsat8_l1tp'
   AND gsd <= 30
   AND eo:cloud_cover <= 10
-  AND datetime >= '2021-04-08T04:39:23Z'
-  AND datetime <= '2021-05-07T12:27:57Z'
+  AND datetime >= TIMESTAMP('2021-04-08T04:39:23Z')
+  AND datetime <= TIMESTAMP('2021-05-07T12:27:57Z')
   AND S_INTERSECTS(geometry, POLYGON((43.5845 -79.5442, 43.6079 -79.4893, 43.5677 -79.4632, 43.6129 -79.3925, 43.6223 -79.3238, 43.6576 -79.3163, 43.7945 -79.1178, 43.8144 -79.1542, 43.8555 -79.1714, 43.7509 -79.6390, 43.5845 -79.5442))
 ```
 
@@ -535,7 +535,7 @@ filter=collection = 'landsat8_l1tp'
       },
       { 
         "op": ">=", 
-        "args": [ { "property": "datetime" }, "2021-04-08T04:39:23Z" ] 
+        "args": [ { "property": "datetime" }, { "timestamp": "2021-04-08T04:39:23Z" } ] 
       },
       {
         "op": "s_intersects", 
@@ -781,7 +781,7 @@ have any overlap between them.
 #### Example 6: T_INTERSECTS cql2-text (GET)
 
 ```http
-filter=datetime T_INTERSECTS 2020-11-11T00:00:00Z/2020-11-12T00:00:00Z
+filter=datetime T_INTERSECTS INTERVAL('2020-11-11T00:00:00Z', '2020-11-12T00:00:00Z')
 ```
 
 #### Example 6: T_INTERSECTS cql2-json (POST)
@@ -793,7 +793,7 @@ filter=datetime T_INTERSECTS 2020-11-11T00:00:00Z/2020-11-12T00:00:00Z
     "op": "t_intersects", 
     "args": [
       { "property": "datetime" },
-      [ "2020-11-11T00:00:00Z", "2020-11-12T00:00:00Z"]
+      { "interval" : [ "2020-11-11T00:00:00Z", "2020-11-12T00:00:00Z"] }
     ]
   }
 }


### PR DESCRIPTION
**Related Issue(s):** n/a


**Proposed Changes:**

1. Several Filter Extension Interval and Timestamp examples are incorrect wrt to the latest CQL spec

**PR Checklist:**

- [X] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [X] This PR has **no** breaking changes.
- [X] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [ ] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
