### PR TITLE
update changelog dates to 2021 instead of 2020, set date of beta.5 re…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v1.0.0-beta.5 - Unreleased] - TBD
+## [v1.0.0-beta.5] - 2022-01-11
 
 ### Added
 
@@ -55,7 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - definition of Item object was missing `properties` as an attribute
 - Filter Extension - examples of using intervals and timestamps in CQL2 were incorrect and have been fixed
 
-## [v1.0.0-beta.4] - 2020-10-05
+## [v1.0.0-beta.4] - 2021-10-05
 
 ### Added
 
@@ -90,7 +90,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-## [v1.0.0-beta.3] - 2020-08-06
+## [v1.0.0-beta.3] - 2021-08-06
 
 ### Added
 - Added STAC API - Collections definition (subset of STAC API - Features)
@@ -111,7 +111,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
   
-## [v1.0.0-beta.2] - 2020-06-01
+## [v1.0.0-beta.2] - 2021-06-01
 
 ### Added
 - Added Filter extension to integrate OAFeat Part 3 CQL

--- a/browseable/README.md
+++ b/browseable/README.md
@@ -10,7 +10,7 @@
 - **Conformance URIs:** 
   - <https://api.stacspec.org/v1.0.0-beta.5/browseable>
   - <https://api.stacspec.org/v1.0.0-beta.5/core>
-- **[Maturity Classification](../README.md#maturity-classification):** Pilot
+- **[Maturity Classification](../README.md#maturity-classification):** Proposal
 - **Dependencies**: [STAC API - Core](../core)
 
 A STAC API conforming to the `STAC API - Browseable` conformance class must be structured such that all 

--- a/children/README.md
+++ b/children/README.md
@@ -10,7 +10,7 @@
 - **Conformance URIs:** 
   - <https://api.stacspec.org/v1.0.0-beta.5/children>
   - <https://api.stacspec.org/v1.0.0-beta.5/core>
-- **[Maturity Classification](../README.md#maturity-classification):** Pilot
+- **[Maturity Classification](../README.md#maturity-classification):** Proposal
 - **Dependencies**: [STAC API - Core](../core)
 
 A STAC API Landing Page (a Catalog) can return information about the Catalog and Collection child objects

--- a/collections/README.md
+++ b/collections/README.md
@@ -10,7 +10,7 @@
 - **Conformance URIs:** 
   - <https://api.stacspec.org/v1.0.0-beta.5/collections>
   - <https://api.stacspec.org/v1.0.0-beta.5/core>
-- **[Maturity Classification](../README.md#maturity-classification):** Pilot
+- **[Maturity Classification](../README.md#maturity-classification):** Proposal
 - **Dependencies**: [STAC API - Core](../core)
 
 A STAC API can return information about all STAC [Collections](../stac-spec/collection-spec/collection-spec.md) available using a link


### PR DESCRIPTION
…lease, update 3 ccs to Proposal instead of Pilot

**Related Issue(s):** #249


**Proposed Changes:**

1. update changelog dates to 2021 instead of 2020 (oops!)
2. update changelog date fro beta.5 from TBD to today
3. update new conformance classes (collection, browseable, and children) to be Proposal instead of Pilot as there are no implementations

**PR Checklist:**

- [X] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [X] This PR has **no** breaking changes.
- [X] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
