### PR TITLE
dev -> master merge for 1.0.0-beta.5 (second attempt)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v1.0.0-beta.5 - Unreleased] - TBD
+## [v1.0.0-beta.5] - 2022-01-11
 
 ### Added
 
@@ -56,7 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Filter Extension - examples of using intervals and timestamps in CQL2 were incorrect and have been fixed
 - Filter Extension - examples are updated so that text and json examples are equivalent
 
-## [v1.0.0-beta.4] - 2020-10-05
+## [v1.0.0-beta.4] - 2021-10-05
 
 ### Added
 
@@ -91,7 +91,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-## [v1.0.0-beta.3] - 2020-08-06
+## [v1.0.0-beta.3] - 2021-08-06
 
 ### Added
 - Added STAC API - Collections definition (subset of STAC API - Features)
@@ -112,7 +112,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-## [v1.0.0-beta.2] - 2020-06-01
+## [v1.0.0-beta.2] - 2021-06-01
 
 ### Added
 - Added Filter extension to integrate OAFeat Part 3 CQL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v1.0.0-beta.5] - 2022-01-11
+## [v1.0.0-beta.5] - 2022-01-14
 
 ### Added
 

--- a/browseable/README.md
+++ b/browseable/README.md
@@ -10,7 +10,7 @@
 - **Conformance URIs:** 
   - <https://api.stacspec.org/v1.0.0-beta.5/browseable>
   - <https://api.stacspec.org/v1.0.0-beta.5/core>
-- **Extension [Maturity Classification](../extensions.md#extension-maturity):** Pilot
+- **[Maturity Classification](../README.md#maturity-classification):** Pilot
 - **Dependencies**: [STAC API - Core](../core)
 
 A STAC API conforming to the `STAC API - Browseable` conformance class must be structured such that all 
@@ -36,7 +36,8 @@ every Item in the Catalog can be accessed by traversing these relations.
 | `item`  | various  | STAC Core | The child STAC Items.                  |
 
 Note that there is a different link relation `items` (plural)
-used by the `STAC API - Features` conformance class that links from a collection resource (at the `/collections/{collectionId}` endpoint) to the items in
+used by the `STAC API - Features` conformance class that links from a collection resource
+(at the `/collections/{collectionId}` endpoint) to the items in
 that collection (at the `/collections/{collectionId}/items` endpoint). Both of these endpoints are 
 [derived from OGC API - Features](https://docs.opengeospatial.org/is/17-069r3/17-069r3.html#_items_).
 

--- a/browseable/README.md
+++ b/browseable/README.md
@@ -10,7 +10,7 @@
 - **Conformance URIs:** 
   - <https://api.stacspec.org/v1.0.0-beta.5/browseable>
   - <https://api.stacspec.org/v1.0.0-beta.5/core>
-- **[Maturity Classification](../README.md#maturity-classification):** Pilot
+- **[Maturity Classification](../README.md#maturity-classification):** Proposal
 - **Dependencies**: [STAC API - Core](../core)
 
 A STAC API conforming to the `STAC API - Browseable` conformance class must be structured such that all 

--- a/children/README.md
+++ b/children/README.md
@@ -10,7 +10,7 @@
 - **Conformance URIs:** 
   - <https://api.stacspec.org/v1.0.0-beta.5/children>
   - <https://api.stacspec.org/v1.0.0-beta.5/core>
-- **[Maturity Classification](../README.md#maturity-classification):** Pilot
+- **[Maturity Classification](../README.md#maturity-classification):** Proposal
 - **Dependencies**: [STAC API - Core](../core)
 
 A STAC API Landing Page (a Catalog) can return information about the Catalog and Collection child objects

--- a/children/README.md
+++ b/children/README.md
@@ -10,7 +10,7 @@
 - **Conformance URIs:** 
   - <https://api.stacspec.org/v1.0.0-beta.5/children>
   - <https://api.stacspec.org/v1.0.0-beta.5/core>
-- **Extension [Maturity Classification](../extensions.md#extension-maturity):** Pilot
+- **[Maturity Classification](../README.md#maturity-classification):** Pilot
 - **Dependencies**: [STAC API - Core](../core)
 
 A STAC API Landing Page (a Catalog) can return information about the Catalog and Collection child objects

--- a/collections/README.md
+++ b/collections/README.md
@@ -10,7 +10,7 @@
 - **Conformance URIs:** 
   - <https://api.stacspec.org/v1.0.0-beta.5/collections>
   - <https://api.stacspec.org/v1.0.0-beta.5/core>
-- **[Maturity Classification](../README.md#maturity-classification):** Pilot
+- **[Maturity Classification](../README.md#maturity-classification):** Proposal
 - **Dependencies**: [STAC API - Core](../core)
 
 A STAC API can return information about all STAC [Collections](../stac-spec/collection-spec/collection-spec.md) available using a link

--- a/core/README.md
+++ b/core/README.md
@@ -114,7 +114,8 @@ search over only a sub-catalog. This is useful for very large or federated catal
 over the entire catalog, but can support searching over individual sub-catalogs within it.
 
 Note that there is a different link relation `items` (plural)
-used by the `STAC API - Features` conformance class that links from a collection resource (at the `/collections/{collectionId}` endpoint) to the items in
+used by the `STAC API - Features` conformance class that links from a collection resource
+(at the `/collections/{collectionId}` endpoint) to the items in
 that collection (at the `/collections/{collectionId}/items` endpoint). Both of these endpoints are 
 [derived from OGC API - Features](https://docs.opengeospatial.org/is/17-069r3/17-069r3.html#_items_).
 
@@ -213,7 +214,7 @@ None.
 A STAC API is more useful when it presents a complete `Catalog` representation of all the data contained in the
 API, such that all `Item` objects can be reached by transitively traversing `child` and `item` link relations from
 the root. This property of being able to reach all Items in this way is formalized in the
-[`STAC API - Browseable` conformance class](../browseable/README.md], but any Catalog can be structured for hierarchical traversal. 
+[`STAC API - Browseable` conformance class](../browseable/README.md), but any Catalog can be structured for hierarchical traversal. 
 Implementers who have search as their primary use case should consider also implementing this
 alternate view over the data by presenting it as a directed graph of catalogs, where the `child` link relations typically
 form a tree, and where each catalog can be retrieved with a single request (e.g., each Catalog JSON is small enough that


### PR DESCRIPTION
merge (again) for 1.0.0-beta.5

This includes mostly formatting changes to remove the stray space at the end of lines, fixes a few of the CQL2 examples, and updates the newer conformance classes to be Proposal instead of Pilot.