### PR TITLE
add type=application/geo+json to prev and next links

### DIFF
--- a/item-search/README.md
+++ b/item-search/README.md
@@ -152,11 +152,13 @@ parameter name is defined by the implementor and is not necessarily part of the 
     "links": [
         {
             "rel": "next",
-            "href": "http://api.cool-sat.com/search?page=3"
+            "href": "http://api.cool-sat.com/search?page=3",
+            "type": "application/geo+json"
         },
         {
             "rel": "prev",
-            "href": "http://api.cool-sat.com/search?page=1"
+            "href": "http://api.cool-sat.com/search?page=1",
+            "type": "application/geo+json"
         }
     ]
 }

--- a/item-search/examples.md
+++ b/item-search/examples.md
@@ -34,7 +34,8 @@ Response with `200 OK`:
     "links": [
         {
             "rel": "next",
-            "href": "http://api.cool-sat.com/search?page=2"
+            "href": "http://api.cool-sat.com/search?page=2",
+            "type": "application/geo+json"
         }
     ]
 }
@@ -58,6 +59,7 @@ Response with `200 OK`:
         {
             "rel": "next",
             "href": "http://api.cool-sat.com/search",
+            "type": "application/geo+json",
             "method": "POST",
             "body": {
                 "page": 2,
@@ -89,6 +91,7 @@ Response with `200 OK`:
 {
     "rel": "next",
     "href": "http://api.cool-sat.com/search",
+    "type": "application/geo+json",
     "method": "POST",
     "body": {
         "next": "a9f3kfbc98e29a0da23"
@@ -123,6 +126,7 @@ Response with `200 OK`:
         {
             "rel": "next",
             "href": "http://api.cool-sat.com/search",
+            "type": "application/geo+json",
             "method": "POST",
             "headers": {
                 "Search-After": "LC81530752019135LGN00"

--- a/ogcapi-features/README.md
+++ b/ogcapi-features/README.md
@@ -126,7 +126,8 @@ or `token` and any additional filter parameters if given and required. For examp
     "links": [
         {
             "rel": "next",
-            "href": "http://api.cool-sat.com/collections/my_collection/items?page=2"
+            "href": "http://api.cool-sat.com/collections/my_collection/items?page=2",
+            "type": "application/geo+json"
         }
     ]
 ```
@@ -175,11 +176,13 @@ previous (page=2) pages:
   ...
   {
     "rel": "prev",
-    "href": "http://api.cool-sat.com/collections?page=2"
+    "href": "http://api.cool-sat.com/collections?page=2",
+    "type": "application/geo+json"
   },
   {
     "rel": "next",
-    "href": "http://api.cool-sat.com/collections?page=4"
+    "href": "http://api.cool-sat.com/collections?page=4",
+    "type": "application/geo+json"
   }
 ]
 ```


### PR DESCRIPTION
**Related Issue(s):** #256


**Proposed Changes:**

1. add type=application/geo+json to prev and next link relations

**PR Checklist:**

- [X] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [X] This PR has **no** breaking changes.
- [X] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
