### PR TITLE
explicitly state /children may return fewer fields for its entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The required Link Relations and endpoints for each conformance class now use the wording of 'shall'
   instead of 'should'. While this technically changes the semantics, it was generally understood
   previously the semantics were those of 'shall' (must).
+- Explicitly state that the `/children` endpoint can return Catalog and Collection objects that have fewer
+  fields than are available through other endpoints.
 
 ### Deprecated
 

--- a/children/README.md
+++ b/children/README.md
@@ -22,7 +22,8 @@ the immediate children of a Catalog, which may be Catalog or Collection objects.
 While the `child` link relations in a Catalog already allow for describing these
 relationships, this scheme requires a client to retrieve each resource URL to find any information about
 the children (e.g., title, description), which can cause significant performance issues in user-facing
-applications.
+applications. Implementers may choose to to return only a subset of fields for each Catalog or Collection,
+but the objects must still be valid Catalogs and Collections.
 
 ## Link Relations
 


### PR DESCRIPTION
**Related Issue(s):** 

- #248 


**Proposed Changes:**

1. explicitly state /children may return a subset of fields 

**PR Checklist:**

- [X] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [X] This PR has **no** breaking changes.
- [X] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
