### PR TITLE
Add Releases to readme and add all conformance classes to build index

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,23 @@
 # STAC API
 
 - [STAC API](#stac-api)
+  - [Releases](#releases)
   - [About](#about)
   - [Stability Note](#stability-note)
   - [Maturity Classification](#maturity-classification)
   - [Communication](#communication)
   - [In this repository](#in-this-repository)
   - [Contributing](#contributing)
+
+## Releases
+
+- [v1.0.0-rc.1](https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-rc.1)
+- [v1.0.0-beta.5](https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-beta.5)
+- [v1.0.0-beta.4](https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-beta.4)
+- [v1.0.0-beta.3](https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-beta.3)
+- [v1.0.0-beta.2](https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-beta.2)
+- [v1.0.0-beta.1](https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-beta.1)
+- [v0.9.0](https://github.com/radiantearth/stac-api-spec/tree/v0.9.0)
 
 ## About
 

--- a/build/index.html
+++ b/build/index.html
@@ -13,10 +13,12 @@
     <h1>STAC API</h1>
     <h2>Conformance Classes</h2>
     <ul>
-        <li><a href="core/">Core</a></li>
-        <li><a href="item-search/">Item Search</a></li>
-        <li><a href="ogcapi-features/">STAC Features</a></li>
-        <li><a href="collections/">Collections</a></li>
+        <li><a href="core/">STAC API - Core</a></li>
+        <li><a href="item-search/">STAC API - Item Search</a></li>
+        <li><a href="ogcapi-features/">STAC API - Features</a></li>
+        <li><a href="collections/">STAC API - Collections</a></li>
+        <li><a href="children/">STAC API - Children</a></li>
+        <li><a href="browseable/">STAC API - Browseable</a></li>
     </ul>
 </body>
 


### PR DESCRIPTION
**Related Issue(s):** n/a


**Proposed Changes:**

1. Add Releases list to Readme to make it more clear where to find specific versions of STAC when we move to only having a main branch
2. Add all the conformance classes to the build index

**PR Checklist:**

- [X] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [X] This PR has **no** breaking changes.
- [X] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
