### PR TITLE
remove unused openapi spec elements and fix several stac_version values

### DIFF
--- a/children/openapi.yaml
+++ b/children/openapi.yaml
@@ -38,7 +38,7 @@ paths:
               schema:
                 $ref: '../core/openapi.yaml#/components/schemas/landingPage'
               example:
-                stac_version: 1.0.0-rc.1
+                stac_version: '1.0.0'
                 type: Catalog
                 id: sentinel
                 title: Copernicus Sentinel Imagery
@@ -107,16 +107,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/children'
-    InvalidParameter:
-      description: |-
-        A query parameter has an invalid value.
-      content:
-        application/json:
-          schema:
-            $ref: '../core/commons.yaml#/components/schemas/exception'
-    NotFound:
-      description: |-
-        The requested URI was not found.
     ServerError:
       description: |-
         A server error occurred.

--- a/collections/openapi.yaml
+++ b/collections/openapi.yaml
@@ -39,7 +39,7 @@ paths:
               schema:
                 $ref: '../core/openapi.yaml#/components/schemas/landingPage'
               example:
-                stac_version: 1.0.0-rc.1
+                stac_version: '1.0.0'
                 type: Catalog
                 id: sentinel
                 title: Copernicus Sentinel Imagery
@@ -165,13 +165,6 @@ components:
         application/json:
           schema:
             $ref: '../core/commons.yaml#/components/schemas/collection'
-    InvalidParameter:
-      description: |-
-        A query parameter has an invalid value.
-      content:
-        application/json:
-          schema:
-            $ref: '../core/commons.yaml#/components/schemas/exception'
     NotFound:
       description: |-
         The requested URI was not found.

--- a/core/commons.yaml
+++ b/core/commons.yaml
@@ -148,7 +148,7 @@ components:
                       - type: string
                       - type: number
       example:
-        stac_version: 1.0.0
+        stac_version: '1.0.0'
         stac_extensions: []
         type: Collection
         id: Sentinel-2
@@ -598,7 +598,7 @@ components:
         assets:
           $ref: '#/components/schemas/assets'
       example:
-        stac_version: 1.0.0
+        stac_version: '1.0.0'
         stac_extensions:
           - 'https://stac-extensions.github.io/eo/v1.0.0/schema.json'
           - 'https://stac-extensions.github.io/view/v1.0.0/schema.json'

--- a/core/openapi.yaml
+++ b/core/openapi.yaml
@@ -58,7 +58,7 @@ components:
             $ref: '#/components/schemas/landingPage'
           example:
             type: Catalog
-            stac_version: 1.0.0
+            stac_version: '1.0.0'
             id: sentinel
             title: Copernicus Sentinel Imagery
             description: Catalog of Copernicus Sentinel 1 and 2 imagery.

--- a/ogcapi-features/openapi.yaml
+++ b/ogcapi-features/openapi.yaml
@@ -38,7 +38,7 @@ paths:
               schema:
                 $ref: '../core/openapi.yaml#/components/schemas/landingPage'
               example:
-                stac_version: 1.0.0-rc.1
+                stac_version: '1.0.0'
                 type: Catalog
                 id: sentinel
                 title: Copernicus Sentinel Imagery

--- a/package-lock.json
+++ b/package-lock.json
@@ -4800,7 +4800,7 @@
             "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.0.0-rc.64.tgz",
             "integrity": "sha512-zrM/vcONpbmyDUOpk7Ai7R/yZrT7W1+8ANJUB3b5kzaLQUx4VbrDoT4D6HHHquOnKx+5We4nOPPAi8fi/cqa8g==",
             "dependencies": {
-                "@redocly/openapi-core": "^1.0.0-rc.14",
+                "@redocly/openapi-core": "^1.0.0-beta.54",
                 "@redocly/react-dropdown-aria": "^2.0.11",
                 "classnames": "^2.3.1",
                 "decko": "^1.2.0",
@@ -11289,7 +11289,7 @@
                     "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.0.0-rc.64.tgz",
                     "integrity": "sha512-zrM/vcONpbmyDUOpk7Ai7R/yZrT7W1+8ANJUB3b5kzaLQUx4VbrDoT4D6HHHquOnKx+5We4nOPPAi8fi/cqa8g==",
                     "requires": {
-                        "@redocly/openapi-core": "^1.0.0-rc.14",
+                        "@redocly/openapi-core": "^1.0.0-beta.54",
                         "@redocly/react-dropdown-aria": "^2.0.11",
                         "classnames": "^2.3.1",
                         "decko": "^1.2.0",


### PR DESCRIPTION
**Related Issue(s):** n/a


**Proposed Changes:**

1. remove unused openapi response codes
2. fix several stac_version values

**PR Checklist:**

- [X] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [X] This PR has **no** breaking changes.
- [X] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
