### PR TITLE
Update ref to use booleanExpression

### DIFF
--- a/fragments/filter/openapi.yaml
+++ b/fragments/filter/openapi.yaml
@@ -148,7 +148,7 @@ components:
         A CQL2 filter expression in the 'cql2-text' encoding.
       type: string
     filter-cql2-json:
-      $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/cql2/standard/schema/cql2.yml#/components/schemas/booleanValueExpression'
+      $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features/master/cql2/standard/schema/cql2.yml#/components/schemas/booleanExpression'
     filter-lang:
       description: |
         The CQL2 filter encoding that the 'filter' value uses.


### PR DESCRIPTION
See https://github.com/opengeospatial/ogcapi-features/commit/c1c580116398a8b6c6cd4acb43863ae7461126d3.

**Related Issue(s):** 

- #301

**Proposed Changes:**

1. Use `booleanExpression` instead of `booleanValueExpression`

**PR Checklist:**

- [X] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [X] This PR has **no** breaking changes.
- [X] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [X] A CHANGELOG entry is not required.
