### PR TITLE
fix filter extension is null example

### DIFF
--- a/fragments/filter/README.md
+++ b/fragments/filter/README.md
@@ -930,11 +930,11 @@ filter=sentinel:data_coverage > 50 OR landsat:coverage_percent < 10 OR (sentinel
         "args": [
           {
             "op": "isNull",
-            "args": { "property": "sentinel:data_coverage" }
+            "args": [ { "property": "sentinel:data_coverage" } ]
           },
           {
             "op": "isNull",
-            "args": { "property": "landsat:coverage_percent" }
+            "args": [ { "property": "landsat:coverage_percent" } ]
           }
         ]
       }


### PR DESCRIPTION
**Related Issue(s):** 

- #299 

**Proposed Changes:**

1. Fix Filter Extension example for isNull that was missing array brackets around args value 

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [x] This PR has **no** breaking changes.
- [x] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
