### PR TITLE
Fix conformance classes

### DIFF
--- a/ogcapi-features/README.md
+++ b/ogcapi-features/README.md
@@ -393,7 +393,7 @@ The full description and examples of this are found in the [context fragment](..
 
 ### Filter Extension
 
-- **Conformance URI:** <https://api.stacspec.org/v1.0.0-rc.1/item-search#filter>
+- **Conformance URI:** <https://api.stacspec.org/v1.0.0-rc.1/ogcapi-features#filter>
 - **Extension [Maturity Classification](../README.md#maturity-classification):** Pilot
 - **Definition**: [STAC API - Filter Fragment](../fragments/filter/)
 
@@ -407,7 +407,7 @@ fragment](../fragments/filter/).
 
 ### Query Extension
 
-- **Conformance URI:** <https://api.stacspec.org/v1.0.0-rc.1/item-search#query>
+- **Conformance URI:** <https://api.stacspec.org/v1.0.0-rc.1/ogcapi-features#query>
 - **Extension [Maturity Classification](../README.md#maturity-classification):** Candidate
 - **Definition**: [STAC API - Query Fragment](../fragments/query/)
 


### PR DESCRIPTION
It looks like the conformance classes were copy/pasted from item search, but instead they should contain ogcapi-features.

**PR Checklist:**

- [x] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [ ] This PR has **no** breaking changes.
- [x] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [ ] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/dev/CHANGELOG.md) **or** a CHANGELOG entry is not required.
