### PR TITLE
Fixed example 10 to match CQL2 schema for isBetween

### DIFF
--- a/fragments/filter/README.md
+++ b/fragments/filter/README.md
@@ -962,7 +962,7 @@ filter=eo:cloud_cover BETWEEN 0 AND 50
     "op": "between",
     "args": [
       { "property": "eo:cloud_cover" },
-      [ 0, 50 ]
+      0, 50
     ]
   }
 }


### PR DESCRIPTION
Fixed example 10 to match CQL2 schema for isBetween

**Proposed Changes:**

1. Fixed example 10 to match CQL2 schema for isBetween

**PR Checklist:**

- [X] This PR has **no** breaking changes.
- [X] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [ ] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
