### PR TITLE
revise limit semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - [Query](https://github.com/stac-api-extensions/query)
     - [Children](https://github.com/stac-api-extensions/children)
 
+### Fixed
+
+- Item Search `limit` parameter semantics now align with OAFeat. The server must not return more Items than the limit and a limit value higher than advertised in the
+service description must return a 400 Bad Request status code.
+
 ## [v1.0.0-rc.1] - 2022-03-17
 
 ### Added

--- a/item-search/README.md
+++ b/item-search/README.md
@@ -105,8 +105,8 @@ See [examples](examples.md) for some example requests.
 
 **limit** The limit parameter follows the same semantics of the OAFeat Item resource limit parameter. The value is
 a suggestion to the server as to the maximum number of Item objects the
-client would prefer in the response. The server must return fewer Item objects, but
-may not return more. The OpenAPI specification defines the default and maximum values
+client would prefer in the response. The server may return fewer Item objects, but
+must not return more. The OpenAPI specification defines the default and maximum values
 for this parameter. The base specifications define these with a default of 10 and a maximum of 10000, but implementers
 may choose other values to advertise through their `service-desc` endpoint.  If the limit parameter value is greater
 than the advertised maximum limit, the server must return a 400 Bad Request status code.

--- a/item-search/README.md
+++ b/item-search/README.md
@@ -105,13 +105,13 @@ See [examples](examples.md) for some example requests.
 
 **limit** The limit parameter follows the same semantics of the OAFeat Item resource limit parameter. The value is
 a suggestion to the server as to the maximum number of Item objects the
-client would prefer in the response. The OpenAPI specification defines the default and maximum values
+client would prefer in the response. The server must return fewer Item objects, but
+may not return more. The OpenAPI specification defines the default and maximum values
 for this parameter. The base specifications define these with a default of 10 and a maximum of 10000, but implementers
 may choose other values to advertise through their `service-desc` endpoint.  If the limit parameter value is greater
-than the advertised maximum limit, the server must return the maximum possible number of items (ideally, the number
-as the advertised maximum limit), rather than responding with an error.
+than the advertised maximum limit, the server must return a 400 Bad Request status code.
 
-Only one of either **intersects** or **bbox** may be specified.  If both are specified, a 400 Bad Request response
+Only one of either **intersects** or **bbox** may be specified.  If both are specified, a 400 Bad Request status code
 must be returned.
 
 **datetime** The datetime parameter use the same allowed values as the


### PR DESCRIPTION
**Related Issue(s):** 

- #334

**Proposed Changes:**

1. limit semantics now match OAFeat. The limit parameter must be less than the maximum value advertised in the service description and the server must not return more items than the limit parameter. 

**PR Checklist:**

- [X] This PR has **no** breaking changes.
- [X] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
