### PR TITLE
add optional numberMatched and numberReturned fields to ItemCollection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - TBD
 
+### Added
+
+- Added optional `numberMatched` and `numberReturned` fields to ItemCollection to align with OGC Commons
+  and OAFeat.
+
 ### Changed
 
 - Browseable specification has been incorporated into the *STAC API - Core* specification.

--- a/fragments/itemcollection/README.md
+++ b/fragments/itemcollection/README.md
@@ -19,11 +19,13 @@ required fields is a valid STAC ItemCollection.
 
 This object describes a STAC ItemCollection. The fields `type` and `features` are inherited from GeoJSON FeatureCollection.
 
-| Field Name | Type                                                                 | Description                                                                     |
-| ---------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| type       | string                                                               | **REQUIRED.** Always "FeatureCollection" to provide compatibility with GeoJSON. |
-| features   | \[[STAC Item](../../stac-spec/item-spec/item-spec.md)]               | **REQUIRED** A possibly-empty array of Item objects.                            |
-| links      | \[[Link Object](../../stac-spec/item-spec/item-spec.md#link-object)] | An array of Links related to this ItemCollection.                               |
+| Field Name     | Type                                                                 | Description                                                                     |
+| -------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| type           | string                                                               | **REQUIRED.** Always "FeatureCollection" to provide compatibility with GeoJSON. |
+| features       | \[[STAC Item](../../stac-spec/item-spec/item-spec.md)]               | **REQUIRED.** A possibly-empty array of Item objects.                           |
+| links          | \[[Link Object](../../stac-spec/item-spec/item-spec.md#link-object)] | An array of Links related to this ItemCollection.                               |
+| numberMatched  | integer                                                              | The number of Items that meet the selection parameters, possibly estimated.     |
+| numberReturned | integer                                                              | The number of Items in the `features` array.                                    |
 
 ## Extensions
 

--- a/fragments/itemcollection/examples/itemcollection-sample-full.json
+++ b/fragments/itemcollection/examples/itemcollection-sample-full.json
@@ -1,5 +1,7 @@
 {
     "type": "FeatureCollection",
+    "numberMatched": 10,
+    "numberReturned": 1,
     "features": [
         {
             "stac_version": "1.0.0",

--- a/fragments/itemcollection/openapi.yaml
+++ b/fragments/itemcollection/openapi.yaml
@@ -33,3 +33,9 @@ components:
             - rel: next
               href: >-
                 http://api.cool-sat.com/search?next=ANsXtp9mrqN0yrKWhf-y2PUpHRLQb1GT-mtxNcXou8TwkXhi1Jbk
+        numberMatched:
+          type: integer
+          minimum: 0
+        numberReturned:
+          type: integer
+          minimum: 0


### PR DESCRIPTION
**Related Issue(s):** 

- n/a

**Proposed Changes:**

1. add optional numberMatched and numberReturned attributes to ItemCollection. These are recommended for a OCG API - Features Part 1 implemenation of ../items and part of OGC Commons now. stac-server and resto already add these to both ../items and /search ItemCollection responses, and doing this in stac-fastapi would be trivial because of existing support for Context Extension. After making this change, I feel we can also deprecate the Context Extension, but that's a separate decision.

**PR Checklist:**

- [X] This PR has **no** breaking changes.
- [X] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
