### PR TITLE
fix code samples using the http type to use none

### DIFF
--- a/implementation.md
+++ b/implementation.md
@@ -16,7 +16,7 @@ configuration so browser-based UIs running on a different domain may more easily
 
 APIs should acknowledge pre-flight request headers. In general, these header values should be set on responses:
 
-```http
+```
 access-control-allow-origin: *
 access-control-allow-methods: OPTIONS, POST, GET
 access-control-allow-headers: Content-Type

--- a/item-search/README.md
+++ b/item-search/README.md
@@ -73,7 +73,7 @@ a set of values, query parameters must use comma-separated string values with no
 
 ### Query Examples
 
-```http
+```
 GET /search?collections=landsat8,sentinel&bbox=-10.415,36.066,3.779,44.213&limit=200&datetime=2017-05-05T00:00:00Z
 ```
 

--- a/item-search/examples.md
+++ b/item-search/examples.md
@@ -14,7 +14,7 @@ OGC API - Features. It requests 100 results in `mycollection` that is in New Zea
 }
 ```
 
-```http
+```
 GET /search?collections=mycollection&bbox=160.6,-55.95,-170,-25.89&limit=100&datetime=2019-01-01T00:00:00Z/2019-01-01T23:59:59Z
 ```
 
@@ -22,7 +22,7 @@ GET /search?collections=mycollection&bbox=160.6,-55.95,-170,-25.89&limit=100&dat
 
 #### Simple GET based search
 Request:
-```http
+```
 HTTP GET /search?bbox=-110,39.5,-105,40.5
 ```
 
@@ -139,7 +139,7 @@ Response with `200 OK`:
 This tells the client to POST to the search endpoint with the header `Search-After` to obtain the next set of results:
 
 Request:
-```http
+```
 POST /search
 Search-After: LC81530752019135LGN00
 ```

--- a/ogcapi-features/README.md
+++ b/ogcapi-features/README.md
@@ -200,25 +200,25 @@ an OAFeat `items` endpoint.
 
 Request all the data in `mycollection` that is in New Zealand:
 
-```http
+```
 GET /collections/mycollection/items?bbox=160.6,-55.95,-170,-25.89
 ```
 
 Request 100 results in `mycollection` from New Zealand:
 
-```http
+```
 GET /collections/mycollection/items?bbox=160.6,-55.95,-170,-25.89&limit=100
 ```
 
 Request all the data in `mycollection` that is in New Zealand at anytime on January 1st, 2019:
 
-```http
+```
 GET /collections/mycollection/items?bbox=160.6,-55.95,-170,-25.89&datetime=2019-01-01T00:00:00Z/2019-01-01T23:59:59Z
 ```
 
 Request 10 results from the data in `mycollection` from between January 1st (inclusive) and April 1st, 2019 (exclusive):
 
-```http
+```
 GET /collections/mycollection/items?datetime=2019-01-01T00:00:00Z/2019-03-31T23:59:59Z&limit=10
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4072,6 +4072,16 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.22.tgz",
             "integrity": "sha512-qzaYbXVzin6EPjghf/hTdIbnVW1ErMx8rPzwRNJhlbyJhu2SyqlvjGOY/tbUt6VFyzg56lROcOeSQRInpt63Yw=="
         },
+        "node_modules/redoc-cli/node_modules/@types/chokidar": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@types/chokidar/-/chokidar-2.1.3.tgz",
+            "integrity": "sha512-6qK3xoLLAhQVTucQGHTySwOVA1crHRXnJeLwqK6KIFkkKa2aoMFXh+WEi8PotxDtvN6MQJLyYN9ag9P6NLV81w==",
+            "deprecated": "This is a stub types definition. chokidar provides its own type definitions, so you do not need this installed.",
+            "extraneous": true,
+            "dependencies": {
+                "chokidar": "*"
+            }
+        },
         "node_modules/redoc-cli/node_modules/@types/eslint": {
             "version": "8.4.1",
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
@@ -4098,10 +4108,29 @@
             "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
             "peer": true
         },
+        "node_modules/redoc-cli/node_modules/@types/handlebars": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.1.0.tgz",
+            "integrity": "sha512-gq9YweFKNNB1uFK71eRqsd4niVkXrxHugqWFQkeLRJvGjnxsLr16bYtcsG4tOFwmYi0Bax+wCkbf1reUfdl4kA==",
+            "deprecated": "This is a stub types definition. handlebars provides its own type definitions, so you do not need this installed.",
+            "extraneous": true,
+            "dependencies": {
+                "handlebars": "*"
+            }
+        },
         "node_modules/redoc-cli/node_modules/@types/json-schema": {
             "version": "7.0.9",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
             "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
+        },
+        "node_modules/redoc-cli/node_modules/@types/mkdirp": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.1.tgz",
+            "integrity": "sha512-HkGSK7CGAXncr8Qn/0VqNtExEE+PHMWb+qlR1faHMao7ng6P3tAaoWWBMdva0gL5h4zprjIO89GJOLXsMcDm1Q==",
+            "extraneous": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/redoc-cli/node_modules/@types/node": {
             "version": "15.12.2",
@@ -11959,6 +11988,14 @@
                         }
                     }
                 },
+                "@types/chokidar": {
+                    "version": "https://registry.npmjs.org/@types/chokidar/-/chokidar-2.1.3.tgz",
+                    "integrity": "sha512-6qK3xoLLAhQVTucQGHTySwOVA1crHRXnJeLwqK6KIFkkKa2aoMFXh+WEi8PotxDtvN6MQJLyYN9ag9P6NLV81w==",
+                    "extraneous": true,
+                    "requires": {
+                        "chokidar": "*"
+                    }
+                },
                 "@types/eslint": {
                     "version": "8.4.1",
                     "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
@@ -11985,10 +12022,26 @@
                     "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
                     "peer": true
                 },
+                "@types/handlebars": {
+                    "version": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.1.0.tgz",
+                    "integrity": "sha512-gq9YweFKNNB1uFK71eRqsd4niVkXrxHugqWFQkeLRJvGjnxsLr16bYtcsG4tOFwmYi0Bax+wCkbf1reUfdl4kA==",
+                    "extraneous": true,
+                    "requires": {
+                        "handlebars": "*"
+                    }
+                },
                 "@types/json-schema": {
                     "version": "7.0.9",
                     "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
                     "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
+                },
+                "@types/mkdirp": {
+                    "version": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.1.tgz",
+                    "integrity": "sha512-HkGSK7CGAXncr8Qn/0VqNtExEE+PHMWb+qlR1faHMao7ng6P3tAaoWWBMdva0gL5h4zprjIO89GJOLXsMcDm1Q==",
+                    "extraneous": true,
+                    "requires": {
+                        "@types/node": "*"
+                    }
                 },
                 "@types/node": {
                     "version": "15.12.2",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,10 @@
                 "remark-lint-maximum-line-length",
                 150
             ],
+            [
             "remark-lint-fenced-code-flag",
+            false
+            ],
             "remark-lint-fenced-code-marker",
             "remark-lint-no-shell-dollars",
             [

--- a/stac-spec/.circleci/rc.yaml
+++ b/stac-spec/.circleci/rc.yaml
@@ -14,8 +14,7 @@ plugins:
   - - remark-lint-maximum-line-length
     - 150
 # Code
-  - - remark-lint-fenced-code-flag
-    - false
+  - remark-lint-fenced-code-flag
   - remark-lint-fenced-code-marker
   - remark-lint-no-shell-dollars
   - - remark-lint-code-block-style

--- a/stac-spec/.circleci/rc.yaml
+++ b/stac-spec/.circleci/rc.yaml
@@ -14,7 +14,8 @@ plugins:
   - - remark-lint-maximum-line-length
     - 150
 # Code
-  - remark-lint-fenced-code-flag
+  - - remark-lint-fenced-code-flag
+    - false
   - remark-lint-fenced-code-marker
   - remark-lint-no-shell-dollars
   - - remark-lint-code-block-style


### PR DESCRIPTION


**Related Issue(s):** 

- n/a

**Proposed Changes:**

1. fix code samples using the http type to use none, since none of these were http format, they showed red highlights in GH

**PR Checklist:**

- [X] This PR has **no** breaking changes.
- [X] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
