### PR TITLE
fix publishing schemas by renaming default from dev to main

### DIFF
--- a/.circleci/publish.js
+++ b/.circleci/publish.js
@@ -1,7 +1,7 @@
 const ghpages = require('gh-pages');
 
 let args = process.argv.slice(2);
-let tag = 'dev';
+let tag = 'main';
 if (args.length && args[0].trim().length > 0) {
 	tag = args[0];
 }

--- a/stac-spec/.circleci/publish-schemas.js
+++ b/stac-spec/.circleci/publish-schemas.js
@@ -9,7 +9,7 @@ function filterFn (item) {
 }
 
 let args = process.argv.slice(2);
-let tag = 'dev';
+let tag = 'main';
 if (args.length && args[0].trim().length > 0) {
 	tag = args[0];
 }

--- a/stac-spec/.circleci/publish-schemas.js
+++ b/stac-spec/.circleci/publish-schemas.js
@@ -9,7 +9,7 @@ function filterFn (item) {
 }
 
 let args = process.argv.slice(2);
-let tag = 'main';
+let tag = 'dev';
 if (args.length && args[0].trim().length > 0) {
 	tag = args[0];
 }


### PR DESCRIPTION
**Related Issue(s):** 

- n/a

**Proposed Changes:**

1. When renaming the default branch from dev to main, I missed these two uses of dev in the schema publishing scripts. Fixing that.

**PR Checklist:**

- [X] This PR has **no** breaking changes.
- [X] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
