### PR TITLE
1.0.0-rc.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - TBD
+## [1.0.0-rc.2]
 
 ### Changed
 
@@ -222,6 +222,11 @@ service description must return a 400 Bad Request status code.
 See the [stac-spec CHANGELOG](https://github.com/radiantearth/stac-spec/blob/v0.9.0/CHANGELOG.md)
 for STAC API releases prior to or equal to version 0.9.0.
 
-[Unreleased]: <https://github.com/radiantearth/stac-api-spec/compare/master...dev>
-[v1.0.0-beta.1]: <https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-beta.1>
+[Unreleased]: <https://github.com/radiantearth/stac-api-spec/compare/v1.0.0-rc.2...main>
+[v1.0.0-rc.2]: <https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-rc.2>
+[v1.0.0-rc.1]: <https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-rc.1>
+[v1.0.0-beta.5]: <https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-beta.5>
+[v1.0.0-beta.4]: <https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-beta.4>
+[v1.0.0-beta.3]: <https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-beta.3>
 [v1.0.0-beta.2]: <https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-beta.2>
+[v1.0.0-beta.1]: <https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-beta.1>

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@
 
 ## Releases (stable)
 
-- [v1.0.0-rc.1](https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-rc.1) (latest)
+- [v1.0.0-rc.2](https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-rc.2) (latest)
+- [v1.0.0-rc.1](https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-rc.1)
 - [v1.0.0-beta.5](https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-beta.5)
 - [v1.0.0-beta.4](https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-beta.4)
 - [v1.0.0-beta.3](https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-beta.3)
@@ -55,12 +56,12 @@ to search STAC catalogs, where the features returned are STAC [Item](stac-spec/i
 that have common properties, links to their assets and geometries that represent the footprints of the geospatial assets.
 
 The specification for STAC API is provided as files that follow the [OpenAPI](http://openapis.org/) 3.0 specification, 
-rendered online into HTML at <https://api.stacspec.org/v1.0.0-rc.1>, in addition to human-readable documentation.  
+rendered online into HTML at <https://api.stacspec.org/v1.0.0-rc.2>, in addition to human-readable documentation.  
 
 ## Stability Note
 
 This specification has evolved over the past couple years, and is used in production in a variety of deployments. It is 
-currently in a 'beta' state, with no major changes anticipated. For 1.0.0-rc.1, we remain fully aligned with [OGC API - 
+currently in a 'beta' state, with no major changes anticipated. For v1.0.0-rc.2, we remain fully aligned with [OGC API - 
 Features](http://docs.opengeospatial.org/is/17-069r3/17-069r3.html) Version 1.0, and we are working to stay aligned
 as the additional OGC API components mature. This may result in minor changes as things evolve. The STAC API 
 specification follows [Semantic Versioning](https://semver.org/), so once 1.0.0 is reached any breaking change 

--- a/build/swagger-config.yaml
+++ b/build/swagger-config.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: STAC API - Complete
-  version: 1.0.0-beta.5
+  version: 1.0.0-rc.2
 apis:
   - url: 'build/core/openapi.yaml'
     paths:

--- a/core/README.md
+++ b/core/README.md
@@ -7,19 +7,19 @@
   - [Extensions](#extensions)
   - [Structuring Catalog Hierarchies](#structuring-catalog-hierarchies)
 
-- **OpenAPI specification:** [openapi.yaml](openapi.yaml) ([rendered version](https://api.stacspec.org/v1.0.0-rc.1/core)),
+- **OpenAPI specification:** [openapi.yaml](openapi.yaml) ([rendered version](https://api.stacspec.org/v1.0.0-rc.2/core)),
 - **Conformance URIs:**
-  - <https://api.stacspec.org/v1.0.0-rc.1/core>
-  - <https://api.stacspec.org/v1.0.0-rc.1/browseable>
+  - <https://api.stacspec.org/v1.0.0-rc.2/core>
+  - <https://api.stacspec.org/v1.0.0-rc.2/browseable>
 - **[Maturity Classification](../README.md#maturity-classification):** Candidate
 - **Dependencies**: None
   and [commons.yaml](commons.yaml) is the OpenAPI version of the core [STAC spec](../stac-spec) JSON Schemas.
 
 All STAC API implementations must implement the *STAC API - Core* specification. The conformance class
-<https://api.stacspec.org/v1.0.0-rc.1/core> requires a server to provide a valid
+<https://api.stacspec.org/v1.0.0-rc.2/core> requires a server to provide a valid
 [STAC Catalog](../stac-spec/catalog-spec/catalog-spec.md) that also includes a `conformsTo`
 attribute with a string array value. Any API implementing this is considered a valid STAC API. Additionally, 
-a STAC API conforming conformance class (<https://api.stacspec.org/v1.0.0-rc.1/browseable>) must be structured
+a STAC API conforming conformance class (<https://api.stacspec.org/v1.0.0-rc.2/browseable>) must be structured
 such that all Items in the catalog can be accessed by following `child` and `item` link relations. 
 
 Even if a STAC catalog is simply files on a web server or objects in cloud storage, serving these files over HTTP
@@ -31,7 +31,7 @@ this "browse" mode of interaction is complementary to the dynamic search capabil
 Conversely, STAC API implementations may not support browse, even though the root is a Catalog object, if they do not
 have the appropriate `child` and `item` link relations to traverse over the objects in the catalog. STAC API
 implementations may provide an even greater guarantee of Item reachability with the
-browseable conformance class (<https://api.stacspec.org/v1.0.0-rc.1/browseable>).
+browseable conformance class (<https://api.stacspec.org/v1.0.0-rc.2/browseable>).
 
 Providing these two complementary ways of interacting with the catalog allow users to iteratively interrogate the data
 to discover what data is available through browse and filter the data to only what they are interested in
@@ -76,7 +76,7 @@ support the *STAC API - Item Search* conformance class, perhaps because it uses 
 but sub-catalogs whose items are all in one database can support search.
 
 A STAC API conforming to the *STAC API - Browseable* conformance class
-(<https://api.stacspec.org/v1.0.0-rc.1/browseable>) must be structured such that
+(<https://api.stacspec.org/v1.0.0-rc.2/browseable>) must be structured such that
 all Items in the catalog can be accessed by following `child` and `item` link relations. This is a more significant
 constraint than a STAC API without this conformance class or a STAC Catalog that is available over HTTP but does not
 implement STAC API, neither of which have any guarantee regarding the reachability of Items. This conformance 
@@ -114,7 +114,7 @@ Additionally, `child` relations may exist to child Catalogs and Collections and 
 relations form a directed graph that enables traversal from a root catalog or collection to items. 
 
 If all Items in a Catalog can be accessed by traversing these links, the browseable conformance class
-<https://api.stacspec.org/v1.0.0-rc.1/browseable> should be advertised also.
+<https://api.stacspec.org/v1.0.0-rc.2/browseable> should be advertised also.
 
 | **rel** | **href** | **From**  | **Description**                        |
 | ------- | -------- | --------- | -------------------------------------- |
@@ -186,7 +186,7 @@ different conformance classes and a different set of links.
     "description": "This Catalog aims to demonstrate the a simple landing page",
     "type": "Catalog",
     "conformsTo" : [
-        "https://api.stacspec.org/v1.0.0-rc.1/core"
+        "https://api.stacspec.org/v1.0.0-rc.2/core"
     ],
     "links": [
         {

--- a/core/commons.yaml
+++ b/core/commons.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: The SpatioTemporal Asset Catalog API - Commons
   description: This is the OpenAPI version of the core STAC spec JSON Schemas.
-  version: 1.0.0-rc.1
+  version: 1.0.0-rc.2
 paths: {}
 components:
   responses:

--- a/core/openapi.yaml
+++ b/core/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: STAC API - Core
-  version: 1.0.0-rc.1
+  version: 1.0.0-rc.2
   description: >-
     This is an OpenAPI definition of the SpatioTemporal Asset Catalog API - Core
     specification. Any service that implements this endpoint to allow discovery of
@@ -63,7 +63,7 @@ components:
             title: Copernicus Sentinel Imagery
             description: Catalog of Copernicus Sentinel 1 and 2 imagery.
             conformsTo:
-              - 'https://api.stacspec.org/v1.0.0-rc.1/core'
+              - 'https://api.stacspec.org/v1.0.0-rc.2/core'
             links:
               - href: 'http://data.example.org/'
                 rel: self

--- a/fragments/itemcollection/openapi.yaml
+++ b/fragments/itemcollection/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: The SpatioTemporal Asset Catalog API - Item Collection
   description: The specification for a set of items, e.g. returned by a search.
-  version: 1.0.0-rc.1
+  version: 1.0.0-rc.2
 paths: {}
 components:
   schemas:

--- a/item-search/README.md
+++ b/item-search/README.md
@@ -15,15 +15,15 @@
   - [Example Landing Page for STAC API - Item Search](#example-landing-page-for-stac-api---item-search)
   - [Extensions](#extensions)
 
-- **OpenAPI specification:** [openapi.yaml](openapi.yaml) ([rendered version](https://api.stacspec.org/v1.0.0-rc.1/item-search))
+- **OpenAPI specification:** [openapi.yaml](openapi.yaml) ([rendered version](https://api.stacspec.org/v1.0.0-rc.2/item-search))
 - **Conformance URIs:**
-  - <https://api.stacspec.org/v1.0.0-rc.1/item-search>
+  - <https://api.stacspec.org/v1.0.0-rc.2/item-search>
 - **[Maturity Classification](../README.md#maturity-classification):** Candidate
 - **Dependencies**: [STAC API - Core](../core)
 - **Examples**: [examples.md](examples.md)
 
 The *STAC API - Item Search* specification defines the *STAC API - Item Search*
-conformance class (<https://api.stacspec.org/v1.0.0-rc.1/item-search>), which
+conformance class (<https://api.stacspec.org/v1.0.0-rc.2/item-search>), which
 provides the ability to search for STAC [Item](../stac-spec/item-spec/README.md)
 objects across collections.
 It retrieves a group of Item objects that match the provided parameters, wrapped in an
@@ -248,8 +248,8 @@ the [overview](../overview.md#example-landing-page) document.
     "description": "This Catalog aims to demonstrate the a simple landing page",
     "type": "Catalog",
     "conformsTo" : [
-        "https://api.stacspec.org/v1.0.0-rc.1/core",
-        "https://api.stacspec.org/v1.0.0-rc.1/item-search"
+        "https://api.stacspec.org/v1.0.0-rc.2/core",
+        "https://api.stacspec.org/v1.0.0-rc.2/item-search"
     ],
     "links": [
         {

--- a/item-search/openapi.yaml
+++ b/item-search/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: STAC API - Item Search
-  version: 1.0.0-rc.1
+  version: 1.0.0-rc.2
   description: >-
     This is an OpenAPI definition of the SpatioTemporal Asset Catalog API - Item Search
     specification.

--- a/ogcapi-features/README.md
+++ b/ogcapi-features/README.md
@@ -19,11 +19,11 @@
 *based on [**OGC API - Features - Part 1: Core**](https://www.ogc.org/standards/ogcapi-features)*
 
 - **OpenAPI specifications:**
-  - [STAC API - Features](openapi-features.yaml) ([rendered version](https://api.stacspec.org/v1.0.0-rc.1/ogcapi-features))
-  - [STAC API - Collections](openapi-collections.yaml) ([rendered version](https://api.stacspec.org/v1.0.0-rc.1/collections))
+  - [STAC API - Features](openapi-features.yaml) ([rendered version](https://api.stacspec.org/v1.0.0-rc.2/ogcapi-features))
+  - [STAC API - Collections](openapi-collections.yaml) ([rendered version](https://api.stacspec.org/v1.0.0-rc.2/collections))
 - **Conformance Class URIs:**
-  - <https://api.stacspec.org/v1.0.0-rc.1/ogcapi-features> - Features
-  - <https://api.stacspec.org/v1.0.0-rc.1/collections> - Collections
+  - <https://api.stacspec.org/v1.0.0-rc.2/ogcapi-features> - Features
+  - <https://api.stacspec.org/v1.0.0-rc.2/collections> - Collections
 - **[Maturity Classification](../README.md#maturity-classification):** Candidate
 - **Dependencies**:
   - [STAC API - Core](../core)
@@ -42,19 +42,19 @@ entities. As these entities are also GeoJSON types, the GeoJSON conformance clas
 
 While OAFeat defines a single conformance class for its endpoints, STAC API divides these behaviors into two
 conformance classes -- Collections and Features. The STAC API - Features
-(<https://api.stacspec.org/v1.0.0-rc.1/ogcapi-features>) conformance class includes and extends the behavior
-of OAFeat, while the STAC API - Collections (<https://api.stacspec.org/v1.0.0-rc.1/collections>) conformance
+(<https://api.stacspec.org/v1.0.0-rc.2/ogcapi-features>) conformance class includes and extends the behavior
+of OAFeat, while the STAC API - Collections (<https://api.stacspec.org/v1.0.0-rc.2/collections>) conformance
 class is the subset of Features that pertains only to Collections.
 
 ### STAC API - Features
 
-The *STAC API - Features* (<https://api.stacspec.org/v1.0.0-rc.1/ogcapi-features>) conformance class
+The *STAC API - Features* (<https://api.stacspec.org/v1.0.0-rc.2/ogcapi-features>) conformance class
 encompasses all of the behavior described in this specification, as
 derived from OAFeat.
 
 ### STAC API - Collections
 
-The *STAC API - Collections* (<https://api.stacspec.org/v1.0.0-rc.1/collections>) conformance class
+The *STAC API - Collections* (<https://api.stacspec.org/v1.0.0-rc.2/collections>) conformance class
 requires only the subset of the behavior of Features that relates to Collections.
 
 This subset is:
@@ -67,7 +67,7 @@ without needing to implement the entire *STAC API - Features* conformance class.
 
 ### OGC API - Features - Part 1: Core
 
-A STAC API implementation that conforms to *STAC API - Features* (<https://api.stacspec.org/v1.0.0-rc.1/ogcapi-features>)
+A STAC API implementation that conforms to *STAC API - Features* (<https://api.stacspec.org/v1.0.0-rc.2/ogcapi-features>)
 also conforms to
 [OGC API - Features - Part 1 Requirements Class Core](http://docs.opengeospatial.org/is/17-069r3/17-069r3.html#rc_core)
 conformance class (<http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core>). 
@@ -310,9 +310,9 @@ the [overview](../overview.md#example-landing-page) document.
     "description": "This Catalog aims to demonstrate the a simple landing page",
     "type": "Catalog",
     "conformsTo" : [
-        "https://api.stacspec.org/v1.0.0-rc.1/core",
-        "https://api.stacspec.org/v1.0.0-rc.1/ogcapi-features",
-        "https://api.stacspec.org/v1.0.0-rc.1/collections",
+        "https://api.stacspec.org/v1.0.0-rc.2/core",
+        "https://api.stacspec.org/v1.0.0-rc.2/ogcapi-features",
+        "https://api.stacspec.org/v1.0.0-rc.2/collections",
         "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
         "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30",
         "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson"

--- a/ogcapi-features/openapi-collections.yaml
+++ b/ogcapi-features/openapi-collections.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: STAC API - Collections
-  version: '1.0.0-rc.1'
+  version: 1.0.0-rc.2
   description: >-
     This is an OpenAPI definition of the SpatioTemporal Asset Catalog API - Collections
     specification.  This is a subset of the STAC API - Features specification.
@@ -45,7 +45,7 @@ paths:
                 title: Copernicus Sentinel Imagery
                 description: Catalog of Copernicus Sentinel 1 and 2 imagery.
                 conformsTo:
-                  - 'https://api.stacspec.org/v1.0.0-rc.1/core'
+                  - 'https://api.stacspec.org/v1.0.0-rc.2/core'
                   - 'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core'
                   - 'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30'
                   - 'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson'

--- a/ogcapi-features/openapi-features.yaml
+++ b/ogcapi-features/openapi-features.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: STAC API - Features
-  version: '1.0.0-rc.1'
+  version: 1.0.0-rc.2
   description: >-
     This is an OpenAPI definition of the SpatioTemporal Asset Catalog API - Features
     specification. This extends OGC API - Features - Part 1: Core.
@@ -44,7 +44,7 @@ paths:
                 title: Copernicus Sentinel Imagery
                 description: Catalog of Copernicus Sentinel 1 and 2 imagery.
                 conformsTo:
-                  - 'https://api.stacspec.org/v1.0.0-rc.1/core'
+                  - 'https://api.stacspec.org/v1.0.0-rc.2/core'
                   - 'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core'
                   - 'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30'
                   - 'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson'

--- a/overview.md
+++ b/overview.md
@@ -33,7 +33,7 @@ located at a `/search` endpoint. It re-uses all of the OAFeat [query
 parameters](http://docs.opengeospatial.org/is/17-069r3/17-069r3.html#_items_) specified in their 'core', and adds a 
 couple more. It does not require a full implementation of OAFeat, it is instead a simplified construct that can run a 
 search across any set of indexed STAC [`Item`](stac-spec/item-spec/README.md) objects. See the [rendered OpenAPI 
-document](https://api.stacspec.org/v1.0.0-rc.2/item-spec) for more details.
+document](https://api.stacspec.org/v1.0.0-rc.2/item-search) for more details.
 
 ### Collections and Features
 

--- a/overview.md
+++ b/overview.md
@@ -20,7 +20,7 @@ point for the more powerful capabilities - it contains a list of URLs, each are 
 'relationships' (`rel`) to indicate their functionality. Note that the [STAC Core specification](stac-spec) provides 
 most of the content of API responses - the STAC API is primarily concerned with the return of STAC 
 [Item](stac-spec/item-spec/README.md) and [Collection](stac-spec/collection-spec/README.md) objects via a 
-web API.  See the [rendered OpenAPI document](https://api.stacspec.org/v1.0.0-rc.1/core) for more details.
+web API.  See the [rendered OpenAPI document](https://api.stacspec.org/v1.0.0-rc.2/core) for more details.
 
 There are then two major sets of functionality that build on the core, which are designed to be complementary, letting
 implementations choose which parts they want to utilize. Almost every STAC API implements at least one and many follow
@@ -33,7 +33,7 @@ located at a `/search` endpoint. It re-uses all of the OAFeat [query
 parameters](http://docs.opengeospatial.org/is/17-069r3/17-069r3.html#_items_) specified in their 'core', and adds a 
 couple more. It does not require a full implementation of OAFeat, it is instead a simplified construct that can run a 
 search across any set of indexed STAC [`Item`](stac-spec/item-spec/README.md) objects. See the [rendered OpenAPI 
-document](https://api.stacspec.org/v1.0.0-rc.1/item-spec) for more details.
+document](https://api.stacspec.org/v1.0.0-rc.2/item-spec) for more details.
 
 ### Collections and Features
 
@@ -50,7 +50,7 @@ is always in GeoJSON and OpenAPI is used to specify STAC API. Full compliance in
 individual `/collections/{collectionId}/items` endpoints that expose querying single collections, as OAFeat does
 not currently allow cross-collection search. And it adds a few other requirements, which are highlighted in the 
 [features description](ogcapi-features/), in order to help STAC implementors understand OAFeat without having to
-read the full spec from scratch. See the [rendered OpenAPI document](https://api.stacspec.org/v1.0.0-rc.1/ogcapi-features)
+read the full spec from scratch. See the [rendered OpenAPI document](https://api.stacspec.org/v1.0.0-rc.2/ogcapi-features)
 for more details.
 
 ### Extensions & Fragments
@@ -107,7 +107,7 @@ column is more of an example in some cases. OGC API makes some endpoint location
 STAC API is evolving to utilize OAFeat's 
 '[Conformance](http://docs.opengeospatial.org/is/17-069r3/17-069r3.html#_declaration_of_conformance_classes)' 
 JSON structure. For 
-STAC API 1.0.0-rc.1 we declare new STAC Conformance classes, with the core ones detailed in the table below. [STAC 
+STAC API, we declare new STAC conformance classes, with the core ones detailed in the table below. [STAC 
 Features](ogcapi-features) requires the core OAFeat conformance classes and declares that those endpoints return 
 STAC Collection and Feature objects.
 The core STAC conformance classes communicate the conformance JSON only in the root (`/`) document, while OGC API 
@@ -123,11 +123,11 @@ have the URIs for conformance to actually resolve to machine-readable informatio
 
 | **Name**               | **Specified in**                            | **Conformance URI**                                    | **Description**                                                                                                 |
 | ---------------------- | ------------------------------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
-| STAC API - Core        | [Core](core)                                | <https://api.stacspec.org/v1.0.0-rc.1/core>            | Specifies the STAC Landing page `/`, communicating conformance and available endpoints.                         |
-| STAC API - Browseable  | [Core](core)                                | <https://api.stacspec.org/v1.0.0-rc.1/browseable>      | Advertises .                                                                                                    |
-| STAC API - Item Search | [Item Search](item-search)                  | <https://api.stacspec.org/v1.0.0-rc.1/item-search>     | Enables search of all STAC Item objects on the server, with the STAC `[/search](#stac-api-endpoints)` endpoint. |
-| STAC API - Features    | [Collections and Features](ogcapi-features) | <https://api.stacspec.org/v1.0.0-rc.1/ogcapi-features> | Specifies the use of OGC API - Features to serve STAC Item and Collection objects                               |
-| STAC API - Collections | [Collections and Features](ogcapi-features) | <https://api.stacspec.org/v1.0.0-rc.1/collections>     | Specifies the use of a subset of STAC API - Features to serve Collection objects                                |
+| STAC API - Core        | [Core](core)                                | <https://api.stacspec.org/v1.0.0-rc.2/core>            | Specifies the STAC Landing page `/`, communicating conformance and available endpoints.                         |
+| STAC API - Browseable  | [Core](core)                                | <https://api.stacspec.org/v1.0.0-rc.2/browseable>      | Advertises .                                                                                                    |
+| STAC API - Item Search | [Item Search](item-search)                  | <https://api.stacspec.org/v1.0.0-rc.2/item-search>     | Enables search of all STAC Item objects on the server, with the STAC `[/search](#stac-api-endpoints)` endpoint. |
+| STAC API - Features    | [Collections and Features](ogcapi-features) | <https://api.stacspec.org/v1.0.0-rc.2/ogcapi-features> | Specifies the use of OGC API - Features to serve STAC Item and Collection objects                               |
+| STAC API - Collections | [Collections and Features](ogcapi-features) | <https://api.stacspec.org/v1.0.0-rc.2/collections>     | Specifies the use of a subset of STAC API - Features to serve Collection objects                                |
 
 Additional conformance classes can be specified by [STAC API Extensions](extensions.md).
 
@@ -149,11 +149,11 @@ The Landing Page will at least have the following `conformsTo` and `links`:
     "description": "This Catalog aims to demonstrate the a simple landing page",
     "type": "Catalog",
     "conformsTo" : [
-        "https://api.stacspec.org/v1.0.0-rc.1/core",
-        "https://api.stacspec.org/v1.0.0-rc.1/browseable",
-        "https://api.stacspec.org/v1.0.0-rc.1/collections",
-        "https://api.stacspec.org/v1.0.0-rc.1/ogcapi-features",
-        "https://api.stacspec.org/v1.0.0-rc.1/item-search",
+        "https://api.stacspec.org/v1.0.0-rc.2/core",
+        "https://api.stacspec.org/v1.0.0-rc.2/browseable",
+        "https://api.stacspec.org/v1.0.0-rc.2/collections",
+        "https://api.stacspec.org/v1.0.0-rc.2/ogcapi-features",
+        "https://api.stacspec.org/v1.0.0-rc.2/item-search",
         "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
         "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30",
         "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson"

--- a/overview.md
+++ b/overview.md
@@ -123,11 +123,11 @@ have the URIs for conformance to actually resolve to machine-readable informatio
 
 | **Name**               | **Specified in**                            | **Conformance URI**                                    | **Description**                                                                                                 |
 | ---------------------- | ------------------------------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
-| STAC API - Core        | [Core](core)                                | <https://api.stacspec.org/v1.0.0-rc.1/core>            | Specifies the STAC Landing page `/`, communicating conformance and available endpoints.                         |
-| STAC API - Browseable  | [Core](core)                                | <https://api.stacspec.org/v1.0.0-rc.1/browseable>      | Advertises all Items can be reached through `child` and `item` links, as they would be in a non-API Catalog.    |
-| STAC API - Item Search | [Item Search](item-search)                  | <https://api.stacspec.org/v1.0.0-rc.1/item-search>     | Enables search of all STAC Item objects on the server, with the STAC `[/search](#stac-api-endpoints)` endpoint. |
-| STAC API - Features    | [Collections and Features](ogcapi-features) | <https://api.stacspec.org/v1.0.0-rc.1/ogcapi-features> | Specifies the use of OGC API - Features to serve STAC Item and Collection objects                               |
-| STAC API - Collections | [Collections and Features](ogcapi-features) | <https://api.stacspec.org/v1.0.0-rc.1/collections>     | Specifies the use of a subset of STAC API - Features to serve Collection objects                                |
+| STAC API - Core        | [Core](core)                                | <https://api.stacspec.org/v1.0.0-rc.2/core>            | Specifies the STAC Landing page `/`, communicating conformance and available endpoints.                         |
+| STAC API - Browseable  | [Core](core)                                | <https://api.stacspec.org/v1.0.0-rc.2/browseable>      | Advertises all Items can be reached through `child` and `item` links, as they would be in a non-API Catalog.    |
+| STAC API - Item Search | [Item Search](item-search)                  | <https://api.stacspec.org/v1.0.0-rc.2/item-search>     | Enables search of all STAC Item objects on the server, with the STAC `[/search](#stac-api-endpoints)` endpoint. |
+| STAC API - Features    | [Collections and Features](ogcapi-features) | <https://api.stacspec.org/v1.0.0-rc.2/ogcapi-features> | Specifies the use of OGC API - Features to serve STAC Item and Collection objects                               |
+| STAC API - Collections | [Collections and Features](ogcapi-features) | <https://api.stacspec.org/v1.0.0-rc.2/collections>     | Specifies the use of a subset of STAC API - Features to serve Collection objects                                |
 
 Additional conformance classes can be specified by [STAC API Extensions](extensions.md).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "api-spec",
-    "version": "1.0.0-rc.1",
+    "version": "1.0.0-rc.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "api-spec",
-            "version": "1.0.0-rc.1",
+            "version": "1.0.0-rc.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "@redocly/openapi-cli": "^1.0.0-beta.94",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "api-spec",
-    "version": "1.0.0-rc.1",
+    "version": "1.0.0-rc.2",
     "description": "STAC API helpers to generate, serve and check the API spec.",
     "repository": "https://github.com/radiantearth/stac-api-spec",
     "license": "Apache-2.0",


### PR DESCRIPTION
**Related Issue(s):** 

- n/a

**Proposed Changes:**

1. Release 1.0.0-rc.2 

<https://github.com/radiantearth/stac-api-spec/compare/v1.0.0-rc.1..main>

## Changelog

### Added

- Added optional `numberMatched` and `numberReturned` fields to ItemCollection to align with OGC Commons
  and OAFeat.

### Changed

- The Collections specification has been incorporated into the *Features* specification, but remains as
  a separate conformance class. 
- The Browseable specification has been incorporated into the *Core* specification, but remains as
  a separate conformance class.
- Extensions moved to standalone specification repositories:
    - [Items and Collections API Version](https://github.com/stac-api-extensions/version) 
    - [Fields](https://github.com/stac-api-extensions/fields)
    - [Filter](https://github.com/stac-api-extensions/filter)
    - [Context](https://github.com/stac-api-extensions/context)
    - [Sort](https://github.com/stac-api-extensions/sort)
    - [Transaction](https://github.com/stac-api-extensions/transaction)
    - [Query](https://github.com/stac-api-extensions/query)
    - [Children](https://github.com/stac-api-extensions/children)

### Fixed

- Item Search `limit` parameter semantics now align with OAFeat. The server must not return more Items than the limit and a limit value higher than advertised in the
service description must return a 400 Bad Request status code.

**PR Checklist:**

- [X] This PR has **no** breaking changes.
- [X] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
