### PR TITLE
Fix typos (repeated "the")

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -56,7 +56,7 @@ In a STAC API, the root endpoint (Landing Page) has the following characteristic
   [Collection](../stac-spec/collection-spec/README.md), and [Item](../stac-spec/item-spec/README.md) objects.
 - The `links` attribute is part of a STAC Catalog, and provides a list of relations to API endpoints. Some of these endpoints can
   exist on any path (e.g., sub-catalogs) and some have a specified path (e.g., `/search`),
-  so the client must inspect the the `rel` (relationship) to understand what capabilities are offered at each location.
+  so the client must inspect the `rel` (relationship) to understand what capabilities are offered at each location.
 - The `conformsTo` section provides the capabilities of this service. This is the field
   that indicates to clients that this is a STAC API and how to access conformance classes, including this
   one. The relevant conformance URIs are listed in each part of the API specification. If a conformance URI is listed then 

--- a/implementation.md
+++ b/implementation.md
@@ -53,7 +53,7 @@ A simple regex for an RFC 3339 datetime is:
 
 This is not a precise regex, as it matches some strings that violate semantics. There are additional restrictions, for example, 
 the month (01-12), the day (01-31), the hour (0-24), minute (0-60), seconds (0-9), and timezone offsets.  However, the best 
-strategy is to use this regex to ensure the datetime conforms to the the RFC 3339 profile and then us an ISO8601 parser to produce
+strategy is to use this regex to ensure the datetime conforms to the RFC 3339 profile and then us an ISO8601 parser to produce
 a valid datetime object from the datetime string.
 
 Thereby, the recommended process for parsing the datetime value (which may consist of a single


### PR DESCRIPTION
**Related Issue(s):** 

N/A

**Proposed Changes:**

1. Remove repeated "the"
   - I confirmed there are no repeated "the" anymore by searching "the the" in this repository.

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [x] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [x] ~I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/main/CHANGELOG.md)~ **or** a CHANGELOG entry is not required.
