### PR TITLE
Fix invalid JSON in item-search/examples.md

### DIFF
--- a/item-search/examples.md
+++ b/item-search/examples.md
@@ -34,7 +34,7 @@ Response with `200 OK`:
     "links": [
         {
             "rel": "next",
-            "https://stac-api.example.com/search?page=2"
+            "href": "https://stac-api.example.com/search?page=2",
             "type": "application/geo+json"
         }
     ]


### PR DESCRIPTION
**Related Issue(s):** 

N/A

**Proposed Changes:**

1. Fix invalid JSON in `item-search/examples.md`
   - https://github.com/radiantearth/stac-api-spec/pull/264 removed `"href"` key

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [x] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [x] ~I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/main/CHANGELOG.md)~ **or** a CHANGELOG entry is not required.
