### PR TITLE
revert change to limit definition in 1.0.0-rc.2 to align with current…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0-rc.2]
+## [Unreleased]
+
+### Fixed
+
+- Item Search `limit` parameter semantics have been changed again to align with the current OAFeat definition, rather than the inconsistent definition in [version 1.0](http://www.opengis.net/doc/IS/ogcapi-features-1/1.0). The new behavior is that if a client requests a limit value above the maximum advertised by the server, that the server should treat the request as if the limit parameter were the maximum value. It must not respond with a error because the the limit value, and must respond with no more than that many items.
+
+## [1.0.0-rc.2] - 2022-11-01
 
 ### Added
 

--- a/item-search/README.md
+++ b/item-search/README.md
@@ -110,7 +110,8 @@ client would prefer in the response. The server may return fewer Item objects, b
 must not return more. The OpenAPI specification defines the default and maximum values
 for this parameter. The base specifications define these with a default of 10 and a maximum of 10000, but implementers
 may choose other values to advertise through their `service-desc` endpoint.  If the limit parameter value is greater
-than the advertised maximum limit, the server must return a 400 Bad Request status code.
+than the advertised maximum limit, the server must act as if the request were for the maximum
+and not return an error.
 
 Only one of either **intersects** or **bbox** may be specified.  If both are specified, a 400 Bad Request status code
 must be returned.


### PR DESCRIPTION
… ogcapi defintion

**Related Issue(s):** 

- #357 

**Proposed Changes:**

1. in rc.2, the definition of limit was changed such that if a value over the maximum were provided, a 400 error should be returned. However, the definition of this behavior in OAFeat 1.0 is inconsistently defined, and has been changed in the latest draft of that spec such that a limit above the maximum is treated as if it were the maximum and not an error. This PR reverts the language to added in rc.2 that an error should be returned.

- [X] This PR has **no** breaking changes.
- [X] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
