### PR TITLE
Remove trailing commas in JSON example

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -212,12 +212,12 @@ different conformance classes and a different set of links.
         {
             "rel": "child",
             "type": "application/json",
-            "href": "https://stac-api.example.com/catalogs/sentinel-2",
+            "href": "https://stac-api.example.com/catalogs/sentinel-2"
         },
         {
             "rel": "child",
             "type": "application/json",
-            "href": "https://stac-api.example.com/catalogs/landsat-8",
+            "href": "https://stac-api.example.com/catalogs/landsat-8"
         }
     ]
 }


### PR DESCRIPTION
**Related Issue(s):**  None

**Proposed Changes:**

1. Remove trailing commas in JSON as they are usually invalid

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [x] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
