### PR TITLE
Proposal: add concestor link relation

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,7 @@
+{
+    "no-duplicate-header": false,
+    "line-length": {
+        "line_length": 120,
+        "tables": false
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
+<!-- markdownlint-disable MD013 -->
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v1.0.0-rc.3] - TBD
 
 ## Added
 
@@ -14,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Item Search `limit` parameter semantics have been changed again to align with the current OAFeat definition, rather than the inconsistent definition in [version 1.0](http://www.opengis.net/doc/IS/ogcapi-features-1/1.0). The new behavior is that if a client requests a limit value above the maximum advertised by the server, that the server should treat the request as if the limit parameter were the maximum value. It must not respond with a error because the the limit value, and must respond with no more than that many items.
 
-## [1.0.0-rc.2] - 2022-11-01
+## [v1.0.0-rc.2] - 2022-11-01
 
 ### Added
 
@@ -24,29 +26,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The Collections specification has been incorporated into the *Features* specification, but remains as
-  a separate conformance class. 
+  a separate conformance class.
 - The Browseable specification has been incorporated into the *Core* specification, but remains as
   a separate conformance class.
 - Extensions moved to standalone specification repositories:
-    - [Items and Collections API Version](https://github.com/stac-api-extensions/version) 
-    - [Fields](https://github.com/stac-api-extensions/fields)
-    - [Filter](https://github.com/stac-api-extensions/filter)
-    - [Context](https://github.com/stac-api-extensions/context)
-    - [Sort](https://github.com/stac-api-extensions/sort)
-    - [Transaction](https://github.com/stac-api-extensions/transaction)
-    - [Query](https://github.com/stac-api-extensions/query)
-    - [Children](https://github.com/stac-api-extensions/children)
+  - [Items and Collections API Version](https://github.com/stac-api-extensions/version)
+  - [Fields](https://github.com/stac-api-extensions/fields)
+  - [Filter](https://github.com/stac-api-extensions/filter)
+  - [Context](https://github.com/stac-api-extensions/context)
+  - [Sort](https://github.com/stac-api-extensions/sort)
+  - [Transaction](https://github.com/stac-api-extensions/transaction)
+  - [Query](https://github.com/stac-api-extensions/query)
+  - [Children](https://github.com/stac-api-extensions/children)
 
 ### Fixed
 
-- Item Search `limit` parameter semantics now align with OAFeat. The server must not return more Items than the limit and a limit value higher than advertised in the
-service description must return a 400 Bad Request status code.
+- Item Search `limit` parameter semantics now align with OAFeat. The server must not return more Items
+  than the limit and a limit value higher than advertised in the
+  service description must return a 400 Bad Request status code.
 
 ## [v1.0.0-rc.1] - 2022-03-17
 
 ### Added
 
-- The CQL2 Accent and Case-insensitive Comparison 
+- The CQL2 Accent and Case-insensitive Comparison
     (`http://www.opengis.net/spec/cql2/1.0/conf/accent-case-insensitive-comparison`) conformance class
     adds the ACCENTI and CASEI functions for case-insensitive comparison. These replace the UPPER and
     LOWER psuedo-functions that were previously part of the Advanced Comparison Operators class.
@@ -59,7 +62,7 @@ service description must return a 400 Bad Request status code.
 - Clarified behavior of Transaction Extension endpoints:
   - PUT and PATCH of a body that changes the `collection` or `id` is disallowed.
   - POST, PUT, and PATCH do not need to include the `collection` attribute, as it should be derived from the URL.
-  - POST and PUT can be used with a body that is at least a GeoJSON Feature, but does not have to be an Item, but for which 
+  - POST and PUT can be used with a body that is at least a GeoJSON Feature, but does not have to be an Item, but for which
     the server can derive a valid Item, e.g., by populating the id and collection fields or adding links
   - Likewise, POST can be used with a body of a FeatureCollection that contains features that meet the same constraints.
 - Specifications now use the term "must" instead of "shall". The semantics of these words are identical.
@@ -165,20 +168,23 @@ service description must return a 400 Bad Request status code.
 ## [v1.0.0-beta.3] - 2021-08-06
 
 ### Added
+
 - Added STAC API - Collections definition (subset of STAC API - Features)
 - More thorough definitions for valid `datetime` and `bbox` query parameter values.
 
 ### Changed
-- Query extension not deprecated; recommendation to use Filter (https://github.com/radiantearth/stac-api-spec/pull/157)
+
+- Query extension not deprecated; recommendation to use Filter (<https://github.com/radiantearth/stac-api-spec/pull/157>)
 - Filter Extension conformance classes refactored to better align with STAC API use cases.
 - Renamed conformance class "Queryable First Operand"
-  (https://api.stacspec.org/v1.0.0-beta.3/item-search#filter:queryable-first-operand) to
+  (<https://api.stacspec.org/v1.0.0-beta.3/item-search#filter:queryable-first-operand>) to
   "Queryable Second Operand"
-  (https://api.stacspec.org/v1.0.0-beta.3/item-search#filter:queryable-second-operand)
+  (<https://api.stacspec.org/v1.0.0-beta.3/item-search#filter:queryable-second-operand>)
 
 ### Deprecated
 
 ### Removed
+
 - Remove stac_version and stac_extensions fields in ItemCollection
 
 ### Fixed
@@ -186,32 +192,38 @@ service description must return a 400 Bad Request status code.
 ## [v1.0.0-beta.2] - 2021-06-01
 
 ### Added
+
 - Added Filter extension to integrate OAFeat Part 3 CQL
 - Catalog and Collection definitions now have required field "type"
 - Added recommendation to enable CORS for public APIs
 
 ### Changed
+
 - Updated all STAC versions to 1.0.0
 - Passing the `ids` parameter to an item search does not deactivate other query parameters [#125](https://github.com/radiantearth/stac-api-spec/pull/125)
 - The first extent in a Collection is always the overall extent, followed by more specific extents. [opengeospatial/ogcapi-features#520](https://github.com/opengeospatial/ogcapi-features/pull/520)
 
 ### Deprecated
+
 - Query extension is now deprecated. Replaced by the Filter extension using OGC CQL.
 
 ### Removed
 
 ### Fixed
+
 - Updated text description of root ('/') endpoint (also called landing page) that the return type is a Catalog
 
 ## [v1.0.0-beta.1] - 2020-12-10
 
 ### Added
+
 - The landing page returns the conformance classes in a property `conformsTo`, which mirrors `GET /conformances` from OGC APIs.
 - Conformance classes for all the major functionality and extensions, to be referenced in a new `conformsTo` JSON object in the landing page.
 - Fragments: reusable OpenAPI documents for sort, filter, fields and context, along with explanation of how they work.
 - ItemCollection moved from [STAC Core](https://github.com/radiantearth/stac-spec/blob/v0.9.0/item-spec/itemcollection-spec.md) to this repo.
 
 ### Changed
+
 - Major re-organization of the content and directory structure to make better conformance classes.
   - STAC API Core is the landing page (a STAC catalog and conformance information).
   - Item Search is the `search` cross-collection item search resource.
@@ -229,6 +241,7 @@ service description must return a 400 Bad Request status code.
 ### Removed
 
 ### Fixed
+
 - BBOX openapi yaml to only allow 4 or 6 element arrays
 - Fixed invalid OpenAPI files
 
@@ -237,11 +250,11 @@ service description must return a 400 Bad Request status code.
 See the [stac-spec CHANGELOG](https://github.com/radiantearth/stac-spec/blob/v0.9.0/CHANGELOG.md)
 for STAC API releases prior to or equal to version 0.9.0.
 
-[Unreleased]: <https://github.com/radiantearth/stac-api-spec/compare/v1.0.0-rc.2...main>
-[v1.0.0-rc.2]: <https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-rc.2>
-[v1.0.0-rc.1]: <https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-rc.1>
-[v1.0.0-beta.5]: <https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-beta.5>
-[v1.0.0-beta.4]: <https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-beta.4>
-[v1.0.0-beta.3]: <https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-beta.3>
-[v1.0.0-beta.2]: <https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-beta.2>
-[v1.0.0-beta.1]: <https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-beta.1>
+[v1.0.0-rc.3]: <https://github.com/radiantearth/stac-api-spec/compare/v1.0.0-rc.2...v1.0.0-rc.3>
+[v1.0.0-rc.2]: <https://github.com/radiantearth/stac-api-spec/compare/v1.0.0-rc.1...v1.0.0-rc.2>
+[v1.0.0-rc.1]: <https://github.com/radiantearth/stac-api-spec/compare/v1.0.0-beta.5...v1.0.0-rc.1>
+[v1.0.0-beta.5]: <https://github.com/radiantearth/stac-api-spec/compare/v1.0.0-beta.4...v1.0.0-beta.5>
+[v1.0.0-beta.4]: <https://github.com/radiantearth/stac-api-spec/compare/v1.0.0-beta.3...v1.0.0-beta.4>
+[v1.0.0-beta.3]: <https://github.com/radiantearth/stac-api-spec/compare/v1.0.0-beta.2...v1.0.0-beta.3>
+[v1.0.0-beta.2]: <https://github.com/radiantearth/stac-api-spec/compare/v1.0.0-beta.1...v1.0.0-beta.2>
+[v1.0.0-beta.1]: <https://github.com/radiantearth/stac-api-spec/compare/v0.9.0...v1.0.0-beta.1>

--- a/core/README.md
+++ b/core/README.md
@@ -7,14 +7,6 @@
   - [Extensions](#extensions)
   - [Structuring Catalog Hierarchies](#structuring-catalog-hierarchies)
 
-- **OpenAPI specification:** [openapi.yaml](openapi.yaml) ([rendered version](https://api.stacspec.org/v1.0.0-rc.2/core)),
-- **Conformance URIs:**
-  - <https://api.stacspec.org/v1.0.0-rc.2/core>
-  - <https://api.stacspec.org/v1.0.0-rc.2/browseable>
-- **[Maturity Classification](../README.md#maturity-classification):** Candidate
-- **Dependencies**: None
-  and [commons.yaml](commons.yaml) is the OpenAPI version of the core [STAC spec](../stac-spec) JSON Schemas.
-
 All STAC API implementations must implement the *STAC API - Core* specification. The conformance class
 <https://api.stacspec.org/v1.0.0-rc.2/core> requires a server to provide a valid
 [STAC Catalog](../stac-spec/catalog-spec/catalog-spec.md) that also includes a `conformsTo`
@@ -88,7 +80,7 @@ Recommendations for structuring Catalogs hierarchically can be found in
 
 ## Link Relations
 
-The following Link relations must exist in the Landing Page (root).
+The following Link relations must exist in the Landing Page (root):
 
 | **rel**        | **href** | **From**  | **Description**                                      |
 | -------------- | -------- | --------- | ---------------------------------------------------- |
@@ -101,25 +93,30 @@ OpenAPI 3.0 or 3.1 with media types `application/vnd.oai.openapi` (YAML),
 `application/vnd.oai.openapi+json;version=3.0` (3.0 JSON), or `application/vnd.oai.openapi+json;version=3.1`
 (3.1 JSON).
 
-A `service-doc` endpoint is recommended, but not required. This commonly returns an HTML
+The following Link relations may exist in the Landing Page (root):
+
+| **rel**       | **href**    | **From**        | **Description**                                                                                                                    |
+| ------------- | ----------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `service-doc` | `/api.html` | OAFeat          | A human-consumable service description. The path for this endpoint is only recommended to be `/api.html`, but may be another path. |
+| `concestor`   | various     | STAC API - Core | A link to the most distant ancestor catalog if this catalog is in a tree of sub-catalogs.                                          |
+| `child`       | various     | STAC Core       | The child STAC Catalogs & Collections.                                                                                             |
+| `item`        | various     | STAC Core       | The child STAC Items.                                                                                                              |
+
+The `service-doc` link relation and endpoint is recommended, but not required. This commonly returns an HTML
 page, for example, in the form of [Redoc](https://github.com/Redocly/redoc) interactive API
 , but any format is allowed. The Link `type` field should correspond to whatever format or formats are
 supported by this endpoint, e.g., `text/html`.
 
-| **rel**       | **href**    | **From** | **Description**                                                                                                                    |
-| ------------- | ----------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `service-doc` | `/api.html` | OAFeat   | A human-consumable service description. The path for this endpoint is only recommended to be `/api.html`, but may be another path. |
+The `concestor` link is to the most distant ancestor catalog if this catalog is in a tree of sub-catalogs.
+This link is to the final URL that is reached when recursively following parent link relations. The word was
+coined by Richard Dawkins to describe the genetic concepts of "most recent common ancestor" (MRCA) or
+"last common ancestor" (LCA).
 
-Additionally, `child` relations may exist to child Catalogs and Collections and `item` relations to Items. These
-relations form a directed graph that enables traversal from a root catalog or collection to items. 
+The `child` relations may exist to child Catalogs and Collections and `item` relations to Items. These
+relations form a directed graph that enables traversal from a root catalog or collection to items.
 
 If all Items in a Catalog can be accessed by traversing these links, the browseable conformance class
 <https://api.stacspec.org/v1.0.0-rc.2/browseable> should be advertised also.
-
-| **rel** | **href** | **From**  | **Description**                        |
-| ------- | -------- | --------- | -------------------------------------- |
-| `child` | various  | STAC Core | The child STAC Catalogs & Collections. |
-| `item`  | various  | STAC Core | The child STAC Items.                  |
 
 While it is valid to have `item` links from the landing page, most STAC API implementations 
 serve large numbers of features, so they will typically use several layers of intermediate `child` links before


### PR DESCRIPTION
**Related Issue(s):** 

- #239 

**Proposed Changes:**

1. Add `concestor` link relation to furthest back parent

**PR Checklist:**

- [X] This PR has **no** breaking changes.
- [X] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
