### PR TITLE
in openapi, fix name of /conformance endpoint (was /conformances)

### DIFF
--- a/core/commons.yaml
+++ b/core/commons.yaml
@@ -33,8 +33,8 @@ components:
           description: >-
             A list of all conformance classes implemented by the server.
             In addition to the STAC-specific conformance classes, all OGC-related
-            conformance classes listed at `GET /conformances` must be listed here.
-            This entry should mirror what `GET /conformances` returns, if implemented.
+            conformance classes listed at `GET /conformance` must be listed here.
+            This entry should mirror what `GET /conformance` returns, if implemented.
           type: array
           items:
             type: string


### PR DESCRIPTION
**Related Issue(s):** 

- n/a

**Proposed Changes:**

1. fix `/conformances` -> `/conformance`

**PR Checklist:**

- [X] This PR has **no** breaking changes.
- [X] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
