### PR TITLE
link to STAC API Extensions site instead of listing them

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,8 @@ The *[item-search](item-search)* folder contains the Item Search specification, 
 cross-collection search of STAC Item objects at a `search` endpoint, as well as a number of extensions. 
 
 **Extensions:**
-The *[extensions](extensions.md) document* describes how STAC incubates new functionality, and it links to the existing 
-extensions that can be added to enrich the functionality of a STAC API. Each has an OpenAPI yaml, but some of the yaml
-documents live as fragments in the [fragments/](fragments/) folder. The official list of STAC API Extensions
+The *[extensions](extensions.md) document* describes how STAC adds new functionality
+through extensions. The official list of STAC API Extensions
 is maintained [here](https://stac-api-extensions.github.io).
 
 **Fragments:**

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ cross-collection search of STAC Item objects at a `search` endpoint, as well as 
 **Extensions:**
 The *[extensions](extensions.md) document* describes how STAC adds new functionality
 through extensions. The official list of STAC API Extensions
-is maintained [here](https://stac-api-extensions.github.io).
+is maintained at [stac-api-extensions.github.io](https://stac-api-extensions.github.io).
 
 **Fragments:**
 The *[fragments/](fragments/)* folder contains re-usable building blocks to be used in a STAC API, including common OpenAPI 

--- a/core/README.md
+++ b/core/README.md
@@ -7,14 +7,6 @@
   - [Extensions](#extensions)
   - [Structuring Catalog Hierarchies](#structuring-catalog-hierarchies)
 
-- **OpenAPI specification:** [openapi.yaml](openapi.yaml) ([rendered version](https://api.stacspec.org/v1.0.0-rc.2/core)),
-- **Conformance URIs:**
-  - <https://api.stacspec.org/v1.0.0-rc.2/core>
-  - <https://api.stacspec.org/v1.0.0-rc.2/browseable>
-- **[Maturity Classification](../README.md#maturity-classification):** Candidate
-- **Dependencies**: None
-  and [commons.yaml](commons.yaml) is the OpenAPI version of the core [STAC spec](../stac-spec) JSON Schemas.
-
 All STAC API implementations must implement the *STAC API - Core* specification. The conformance class
 <https://api.stacspec.org/v1.0.0-rc.2/core> requires a server to provide a valid
 [STAC Catalog](../stac-spec/catalog-spec/catalog-spec.md) that also includes a `conformsTo`
@@ -225,7 +217,7 @@ different conformance classes and a different set of links.
 
 ## Extensions
 
-None.
+STAC API Extensions can be found [here](https://stac-api-extensions.github.io).
 
 ## Structuring Catalog Hierarchies
 

--- a/core/README.md
+++ b/core/README.md
@@ -231,7 +231,7 @@ different conformance classes and a different set of links.
 
 ## Extensions
 
-STAC API Extensions can be found [here](https://stac-api-extensions.github.io).
+STAC API Extensions can be found at [stac-api-extensions.github.io](https://stac-api-extensions.github.io).
 
 ## Structuring Catalog Hierarchies
 

--- a/fragments/itemcollection/README.md
+++ b/fragments/itemcollection/README.md
@@ -29,7 +29,8 @@ This object describes a STAC ItemCollection. The fields `type` and `features` ar
 
 ## Extensions
 
-- The [Context Extension](https://github.com/stac-api-extensions/context) adds additional fields to STAC ItemCollection relevant 
-  to their use as search results.
-- The [Single File STAC Extension](https://github.com/stac-extensions/single-file-stac/blob/main/README.md) provides a set of Collection 
-  and Item objects as a single file catalog.
+STAC API Extensions can be found [here](https://stac-api-extensions.github.io).
+
+In addition to STAC API extensions, the STAC
+[Single File STAC Extension](https://github.com/stac-extensions/single-file-stac/blob/main/README.md)
+provides a set of Collection and Item objects as a single file catalog.

--- a/item-search/README.md
+++ b/item-search/README.md
@@ -297,4 +297,4 @@ the [overview](../overview.md#example-landing-page) document.
 
 ## Extensions
 
-STAC API Extensions can be found [here](https://stac-api-extensions.github.io).
+STAC API Extensions can be found at [stac-api-extensions.github.io](https://stac-api-extensions.github.io).

--- a/item-search/README.md
+++ b/item-search/README.md
@@ -15,13 +15,6 @@
   - [Example Landing Page for STAC API - Item Search](#example-landing-page-for-stac-api---item-search)
   - [Extensions](#extensions)
 
-- **OpenAPI specification:** [openapi.yaml](openapi.yaml) ([rendered version](https://api.stacspec.org/v1.0.0-rc.2/item-search))
-- **Conformance URIs:**
-  - <https://api.stacspec.org/v1.0.0-rc.2/item-search>
-- **[Maturity Classification](../README.md#maturity-classification):** Candidate
-- **Dependencies**: [STAC API - Core](../core)
-- **Examples**: [examples.md](examples.md)
-
 The *STAC API - Item Search* specification defines the *STAC API - Item Search*
 conformance class (<https://api.stacspec.org/v1.0.0-rc.2/item-search>), which
 provides the ability to search for STAC [Item](../stac-spec/item-spec/README.md)
@@ -291,10 +284,4 @@ the [overview](../overview.md#example-landing-page) document.
 
 ## Extensions
 
-These extensions provide additional functionality that enhances Item Search.
-
-- [Fields Extension](https://github.com/stac-api-extensions/fields/blob/main/README.md)
-- [Sort Extension](https://github.com/stac-api-extensions/sort/blob/main/README.md)
-- [Context Extension](https://github.com/stac-api-extensions/context/blob/main/README.md)
-- [Filter Extension](https://github.com/stac-api-extensions/filter/blob/main/README.md)
-- [Query Extension](https://github.com/stac-api-extensions/query/blob/main/README.md)
+STAC API Extensions can be found [here](https://stac-api-extensions.github.io).

--- a/ogcapi-features/README.md
+++ b/ogcapi-features/README.md
@@ -396,4 +396,4 @@ as is typical with a static STAC Collection, there are no links here with rel va
 
 ## Extensions
 
-STAC API Extensions can be found [here](https://stac-api-extensions.github.io).
+STAC API Extensions can be found at [stac-api-extensions.github.io](https://stac-api-extensions.github.io).

--- a/ogcapi-features/README.md
+++ b/ogcapi-features/README.md
@@ -392,12 +392,4 @@ as is typical with a static STAC Collection, there are no links here with rel va
 
 ## Extensions
 
-These extensions provide additional functionality that enhances *STAC API - Features*.
-
-- [Transaction Extension](https://github.com/stac-api-extensions/transaction/blob/main/README.md)
-- [Items and Collections API Version Extension](https://github.com/stac-api-extensions/version/blob/main/README.md)
-- [Fields Extension](https://github.com/stac-api-extensions/fields/blob/main/README.md)
-- [Sort Extension](https://github.com/stac-api-extensions/sort/blob/main/README.md)
-- [Context Extension](https://github.com/stac-api-extensions/context/blob/main/README.md)
-- [Filter Extension](https://github.com/stac-api-extensions/filter/blob/main/README.md)
-- [Query Extension](https://github.com/stac-api-extensions/query/blob/main/README.md)
+STAC API Extensions can be found [here](https://stac-api-extensions.github.io).

--- a/overview.md
+++ b/overview.md
@@ -56,8 +56,8 @@ for more details.
 ### Extensions & Fragments
 
 Both STAC API and OAFeat allow 'extensions' that can be added for additional functionality. The STAC community has 
-created a number of extensions to OAFeat, in order to meet the requirements of its implementors and the complete list 
-can be found in the [extensions document](extensions.md), which links to each of them and details their maturity. 
+created [a number of extensions](https://stac-api-extensions.github.io) to OAFeat
+in order to meet the requirements of its implementors. Additional details about extensions can be found in the [extensions document](extensions.md).
 These are specified in OpenAPI, which works cleanly when the new functionality is a new API location (a complete 
 resource, or adding POST to an existing one). Many of the additions, however, are done at the parameter or response 
 level, like adding a `sortby` field to return ordered results. To make these reusable by both Item Search and OAFeat, 


### PR DESCRIPTION
**Related Issue(s):** 

- n/a

**Proposed Changes:**

1. link to STAC API Extensions site instead of listing them

**PR Checklist:**

- [X] This PR has **no** breaking changes.
- [X] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
