### PR TITLE
fix headers so VSCode header won't remove Summary section

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -1,11 +1,15 @@
 # STAC API - Core Specification
 
 - [STAC API - Core Specification](#stac-api---core-specification)
+  - [Summary](#summary)
+  - [Overview](#overview)
   - [Link Relations](#link-relations)
   - [Endpoints](#endpoints)
   - [Example Landing Page for STAC API - Core](#example-landing-page-for-stac-api---core)
   - [Extensions](#extensions)
   - [Structuring Catalog Hierarchies](#structuring-catalog-hierarchies)
+
+## Summary
 
 - **OpenAPI specification:** [openapi.yaml](openapi.yaml) ([rendered version](https://api.stacspec.org/v1.0.0-rc.2/core)),
 - **Conformance URIs:**
@@ -14,6 +18,8 @@
 - **[Maturity Classification](../README.md#maturity-classification):** Candidate
 - **Dependencies**: None
   and [commons.yaml](commons.yaml) is the OpenAPI version of the core [STAC spec](../stac-spec) JSON Schemas.
+
+## Overview
 
 All STAC API implementations must implement the *STAC API - Core* specification. The conformance class
 <https://api.stacspec.org/v1.0.0-rc.2/core> requires a server to provide a valid

--- a/item-search/README.md
+++ b/item-search/README.md
@@ -1,6 +1,8 @@
 # STAC API - Item Search
 
 - [STAC API - Item Search](#stac-api---item-search)
+  - [Summary](#summary)
+  - [Overview](#overview)
   - [Link Relations](#link-relations)
   - [Endpoints](#endpoints)
   - [Query Parameters and Fields](#query-parameters-and-fields)
@@ -15,12 +17,16 @@
   - [Example Landing Page for STAC API - Item Search](#example-landing-page-for-stac-api---item-search)
   - [Extensions](#extensions)
 
+## Summary
+
 - **OpenAPI specification:** [openapi.yaml](openapi.yaml) ([rendered version](https://api.stacspec.org/v1.0.0-rc.2/item-search))
 - **Conformance URIs:**
   - <https://api.stacspec.org/v1.0.0-rc.2/item-search>
 - **[Maturity Classification](../README.md#maturity-classification):** Candidate
 - **Dependencies**: [STAC API - Core](../core)
 - **Examples**: [examples.md](examples.md)
+
+## Overview
 
 The *STAC API - Item Search* specification defines the *STAC API - Item Search*
 conformance class (<https://api.stacspec.org/v1.0.0-rc.2/item-search>), which

--- a/ogcapi-features/README.md
+++ b/ogcapi-features/README.md
@@ -1,6 +1,8 @@
 # STAC API - Collections and Features Specification
 
 - [STAC API - Collections and Features Specification](#stac-api---collections-and-features-specification)
+  - [Summary](#summary)
+  - [Overview](#overview)
   - [Conformance Classes](#conformance-classes)
     - [STAC API - Features](#stac-api---features)
     - [STAC API - Collections](#stac-api---collections)
@@ -16,7 +18,7 @@
   - [Example Collection Endpoint](#example-collection-endpoint)
   - [Extensions](#extensions)
 
-*based on [**OGC API - Features - Part 1: Core**](https://www.ogc.org/standards/ogcapi-features)*
+## Summary
 
 - **OpenAPI specifications:**
   - [STAC API - Features](openapi-features.yaml) ([rendered version](https://api.stacspec.org/v1.0.0-rc.2/ogcapi-features))
@@ -29,6 +31,8 @@
   - [STAC API - Core](../core)
   - [OGC API - Features](https://www.ogc.org/standards/ogcapi-features)
   uses all the OGC API - Features openapi fragments to describe returning STAC Item objects.
+
+## Overview
 
 The *STAC API - Collections and Features* specification extends the
 [OGC API - Features - Part 1: Core](https://docs.opengeospatial.org/is/17-069r3/17-069r3.html)


### PR DESCRIPTION
**Related Issue(s):** 

- n/a

**Proposed Changes:**

1. Add headers to readmes so VS Code markdown-all-in-one won't remove Summary content

**PR Checklist:**

- [ ] This PR has **no** breaking changes.
- [ ] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [ ] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
