### PR TITLE
add openapi extension x-conformance-classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 
 - Added authentication status code recommendations.
+- Added extension field to all OpenAPI specifications `x-conformance-classes` indicating the
+  conformance classes they define.
 
 ### Fixed
 

--- a/core/openapi.yaml
+++ b/core/openapi.yaml
@@ -12,6 +12,7 @@ info:
   license:
     name: Apache License 2.0
     url: 'http://www.apache.org/licenses/LICENSE-2.0'
+  x-conformance-classes: [ "https://api.stacspec.org/v1.0.0-rc.2/core" ]
 tags:
   - name: Core
     description: essential characteristics of a STAC API

--- a/item-search/openapi.yaml
+++ b/item-search/openapi.yaml
@@ -14,6 +14,7 @@ info:
 tags:
   - name: Item Search
     description: essential characteristics of a STAC API
+x-conformance-classes: [ "https://api.stacspec.org/v1.0.0-rc.2/item-search" ]
 paths:
   /search:
     get:

--- a/ogcapi-features/openapi-collections.yaml
+++ b/ogcapi-features/openapi-collections.yaml
@@ -11,6 +11,7 @@ info:
   license:
     name: Apache License 2.0
     url: 'http://www.apache.org/licenses/LICENSE-2.0'
+  x-conformance-classes: [ "https://api.stacspec.org/v1.0.0-rc.2/collections" ]
 tags:
   - name: Core
     description: essential characteristics of a STAC API

--- a/ogcapi-features/openapi-features.yaml
+++ b/ogcapi-features/openapi-features.yaml
@@ -11,6 +11,7 @@ info:
   license:
     name: Apache License 2.0
     url: 'http://www.apache.org/licenses/LICENSE-2.0'
+  x-conformance-classes: [ "https://api.stacspec.org/v1.0.0-rc.2/ogcapi-features" ]
 tags:
   - name: Features
     description: |-


### PR DESCRIPTION
**Related Issue(s):** 

- https://github.com/radiantearth/stac-api-spec/issues/361

**Proposed Changes:**

1. Add x-conformance-classes extension in openapi schemas

**PR Checklist:**

- [X] This PR has **no** breaking changes.
- [X] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
