### PR TITLE
add "root" link rel as required for item search response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added authentication status code recommendations.
 - Added extension field to all OpenAPI specifications `x-conformance-classes` indicating the
   conformance classes they define.
+- STAC API - Item Search now requires a `root` link relation in the response from `/search`
 
 ### Fixed
 

--- a/fragments/itemcollection/examples/itemcollection-sample-full.json
+++ b/fragments/itemcollection/examples/itemcollection-sample-full.json
@@ -60,11 +60,15 @@
             "links": [
                 {
                     "rel": "self",
-                    "href": "https://stac-api.example.com/catalog/CS3-20160503_132130_04/CS3-20160503_132130_04.json"
+                    "href": "https://stac-api.example.com/collections/CS3/items/CS3-20160503_132131_05"
+                },
+                {
+                    "rel": "root",
+                    "href": "https://stac-api.example.com/"
                 },
                 {
                     "rel": "collection",
-                    "href": "https://stac-api.example.com/catalog/CS3-20160503_132130_04/catalog.json"
+                    "href": "https://stac-api.example.com/collections/CS3"
                 }
             ],
             "assets": {
@@ -84,8 +88,9 @@
     ],
     "links": [
         {
-            "rel": "self",
-            "href": "http://stac.example.com/search?collection=CS3"
+            "rel": "root",
+            "href": "http://stac.example.com/",
+            "type": "application/json"
         }
     ]
 }

--- a/item-search/README.md
+++ b/item-search/README.md
@@ -63,6 +63,12 @@ specified, it is assumed to represent a GET request. If the server supports both
 Other links with relation `search` may be included that advertise other content types the server may respond
 with, but these other types are not part of the STAC API requirements.
 
+The following Link relations must exist in the `/search` endpoint response.
+
+| **rel** | **href** | **From**               | **Description** |
+| ------- | -------- | ---------------------- | --------------- |
+| `root`  | `/`      | STAC API - Item Search | The root URI    |
+
 ## Endpoints
 
 This conformance class also requires for the endpoints in the [STAC API - Core](../core) conformance class to be implemented.
@@ -166,6 +172,11 @@ parameter name is defined by the implementor and is not necessarily part of the 
             "rel": "prev",
             "href": "https://stac-api.example.com/search?page=1",
             "type": "application/geo+json"
+        },
+        {
+            "rel": "root",
+            "href": "https://stac-api.example.com/",
+            "type": "application/json"
         }
     ]
 }

--- a/item-search/examples.md
+++ b/item-search/examples.md
@@ -36,6 +36,11 @@ Response with `200 OK`:
             "rel": "next",
             "href": "https://stac-api.example.com/search?page=2",
             "type": "application/geo+json"
+        },
+        {
+            "rel": "root",
+            "href": "https://stac-api.example.com/",
+            "type": "application/json"
         }
     ]
 }
@@ -66,6 +71,11 @@ Response with `200 OK`:
                 "limit": 10
             },
             "merge": true
+        },
+        {
+            "rel": "root",
+            "href": "https://stac-api.example.com/",
+            "type": "application/json"
         }
     ]
 }
@@ -118,6 +128,7 @@ Request to `HTTP POST /search`:
 ```
 
 Response with `200 OK`:
+
 ```json
 {
     "type": "FeatureCollection",
@@ -131,6 +142,11 @@ Response with `200 OK`:
             "headers": {
                 "Search-After": "LC81530752019135LGN00"
             }
+        },
+        {
+            "rel": "root",
+            "href": "https://stac-api.example.com/",
+            "type": "application/json"
         }
     ]
 }


### PR DESCRIPTION
**Related Issue(s):** 

- https://github.com/radiantearth/stac-api-spec/issues/340

**Proposed Changes:**

1. Add `root` as a required link rel on the Item Search response ItemCollection

**PR Checklist:**

- [X] This PR has **no** breaking changes.
- [X] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
