### PR TITLE
Add explicit type restrictions

### DIFF
--- a/core/commons.yaml
+++ b/core/commons.yaml
@@ -53,6 +53,8 @@ components:
           $ref: '#/components/schemas/stac_extensions'
         type:
           type: string
+          enum:
+            - Catalog
         id:
           type: string
         title:
@@ -78,6 +80,8 @@ components:
           $ref: '#/components/schemas/stac_extensions'
         type:
           type: string
+          enum:
+            - Collection
         id:
           description: identifier of the collection used, for example, in URIs
           type: string


### PR DESCRIPTION
**Related Issue(s):** 

- https://github.com/radiantearth/stac-browser/issues/253
- https://github.com/radiantearth/stac-api-spec/issues/388

**Proposed Changes:**

1. Explicit mention of the type values, otherwise Catalogs could be Collections and Collections could be Catalogs with additional Collection fields.

**PR Checklist:**

- [ ] This PR has **no** breaking changes.
- [x] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [ ] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
