### PR TITLE
remove mention of single-file extension

### DIFF
--- a/fragments/itemcollection/README.md
+++ b/fragments/itemcollection/README.md
@@ -30,7 +30,3 @@ This object describes a STAC ItemCollection. The fields `type` and `features` ar
 ## Extensions
 
 STAC API Extensions can be found [here](https://stac-api-extensions.github.io).
-
-In addition to STAC API extensions, the STAC
-[Single File STAC Extension](https://github.com/stac-extensions/single-file-stac/blob/main/README.md)
-provides a set of Collection and Item objects as a single file catalog.


### PR DESCRIPTION
**Related Issue(s):** 

- https://github.com/radiantearth/stac-api-spec/issues/400

**Proposed Changes:**

1. Remove mention of single-file extension for STAC as this is deprecated.

**PR Checklist:**

- [X] This PR has **no** breaking changes.
- [X] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
