### PR TITLE
Use collection relation for links to collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added extension field to all OpenAPI specifications `x-conformance-classes` indicating the
   conformance classes they define.
 - STAC API - Item Search now requires a `root` link relation in the response from `/search`
+- Added a `collection` link from and Item to its Collection to conform with the STAC spec.
 
 ### Fixed
 

--- a/ogcapi-features/README.md
+++ b/ogcapi-features/README.md
@@ -157,8 +157,8 @@ The following Link relations must exist in the Item object returned from the `/c
 | **rel**  | **href**                                     | **Media Type**       | **From**            | **Description**                                     |
 | -------- | -------------------------------------------- | -------------------- | ------------------- | --------------------------------------------------- |
 | `root`   | `/`                                          | application/json     | STAC API - Features | The root URI                                        |
-| `collection` | `/collections/{collectionId}`            | application/json     | STAC Collection     | The containing Collection |
-| `parent` | `/collections/{collectionId}`                | application/json     | OAFeat              | Parent reference, usually the containing Collection |
+| `collection` | `/collections/{collectionId}`            | application/json     | STAC Item           | The containing Collection |
+| `parent` | `/collections/{collectionId}`                | application/json     | STAC Item           | Parent reference, usually the containing Collection |
 | `self`   | `/collections/{collectionId}/items/{itemId}` | application/geo+json | OAFeat              | Self reference                                      |
 
 The `parent` link for an Item may point to a Collection or a Catalog.  The `collection` link for an Item will always point to the containing Collection.  Links to a Collection must point to the `/collections/{collectionId}` endpoint, rather than the API sub-path of `/collections/{collectionId}/items/`.

--- a/ogcapi-features/README.md
+++ b/ogcapi-features/README.md
@@ -157,12 +157,11 @@ The following Link relations must exist in the Item object returned from the `/c
 | **rel**  | **href**                                     | **Media Type**       | **From**            | **Description**                                     |
 | -------- | -------------------------------------------- | -------------------- | ------------------- | --------------------------------------------------- |
 | `root`   | `/`                                          | application/json     | STAC API - Features | The root URI                                        |
+| `collection` | `/collections/{collectionId}`            | application/json     | STAC Collection     | The containing Collection |
 | `parent` | `/collections/{collectionId}`                | application/json     | OAFeat              | Parent reference, usually the containing Collection |
 | `self`   | `/collections/{collectionId}/items/{itemId}` | application/geo+json | OAFeat              | Self reference                                      |
 
-Note that the `parent` link for an Item should point to the containing Collection
-(e.g., `/collections/{collectionId}`), rather than the API sub-path
-of `/collections/{collectionId}/items/`.
+The `parent` link for an item may point to a Collection or a Catalog.  A `collection` link for an Item will always point to the containing Collection.  Links to a Collection must point to the `/collections/{collectionId}` endpoint, rather than the API sub-path of `/collections/{collectionId}/items/`.
 
 ## Endpoints
 

--- a/ogcapi-features/README.md
+++ b/ogcapi-features/README.md
@@ -161,7 +161,7 @@ The following Link relations must exist in the Item object returned from the `/c
 | `parent` | `/collections/{collectionId}`                | application/json     | OAFeat              | Parent reference, usually the containing Collection |
 | `self`   | `/collections/{collectionId}/items/{itemId}` | application/geo+json | OAFeat              | Self reference                                      |
 
-The `parent` link for an item may point to a Collection or a Catalog.  A `collection` link for an Item will always point to the containing Collection.  Links to a Collection must point to the `/collections/{collectionId}` endpoint, rather than the API sub-path of `/collections/{collectionId}/items/`.
+The `parent` link for an Item may point to a Collection or a Catalog.  The `collection` link for an Item will always point to the containing Collection.  Links to a Collection must point to the `/collections/{collectionId}` endpoint, rather than the API sub-path of `/collections/{collectionId}/items/`.
 
 ## Endpoints
 


### PR DESCRIPTION
**Related Issue(s):** 

- [#362](https://github.com/radiantearth/stac-api-spec/issues/362#issuecomment-1457397588)

**Proposed Changes:**

1. Use the `collection` relation type for links from an item to a collection

The STAC Collection spec includes [this language](https://github.com/radiantearth/stac-spec/blob/v1.0.0/collection-spec/collection-spec.md#relation-types):

> it is REQUIRED that Items linked from a Collection MUST refer back to its Collection with the collection relation type

This proposed change makes the STAC API spec consistent with that requirement.

**PR Checklist:**

- [ ] This PR has **no** breaking changes.
- [ ] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
