### PR TITLE
remove from core openapi mention of 'data' link rel, which is in a different spec & conformance class

### DIFF
--- a/core/openapi.yaml
+++ b/core/openapi.yaml
@@ -52,9 +52,7 @@ components:
     LandingPage:
       description: |-
         The landing page provides links to the API definition
-        (link relations `service-desc` and `service-doc`)
-        and the Feature Collection (path `/collections`, link relation
-        `data`).
+        (link relations `service-desc` and `service-doc`).
       content:
         application/json:
           schema:


### PR DESCRIPTION
**Related Issue(s):** 

- #403 

**Proposed Changes:**

1. remove mention of data link rel from core spec, since it's defined in Collections and Features rather than Core

**PR Checklist:**

- [X] This PR has **no** breaking changes.
- [X] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
