### PR TITLE
link type no longer required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.0.0-rc.4] - TBD
+
+## Changed
+
+- Field `type` is no longer required for all Link objects, but is instead strongly recommended
+
 ## [v1.0.0-rc.3] - 2023-03-27
 
 ## Changed
 
 - Browseable has been moved to an extension, now located at <https://github.com/stac-api-extensions/browseable>
 - Link relation `parent` is no longer a required link for Collections or Items
+- Field `type` is now required for all Link objects
 
 ## Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 
-- Field `type` is no longer required for all Link objects, but is instead strongly recommended
+- Field `type` is no longer required for all Link objects, but is instead strongly
+  recommended. This was added as a requirement in 1.0.0-rc.3 based on a mis-reading
+  of the OGC Features spec, and is now removed as a requirement.
 
 ## [v1.0.0-rc.3] - 2023-03-27
 

--- a/core/README.md
+++ b/core/README.md
@@ -63,8 +63,8 @@ but sub-catalogs whose items are all in one database can support search.
 
 ## Link Relations
 
-While the STAC definition of Link does not require the `type` field,
-*STAC API - Core* requires all Links to have this field.
+The STAC definition of Link does not require the `type` field,
+but it is **STRONGLY RECOMMENDED** that this field exists.
 If the target of a Link's `type` is unknown, `type` SHOULD be set to `application/octet-stream` or `text/plain`.
 
 The following Link relations are defined for the Landing Page (root).

--- a/item-search/README.md
+++ b/item-search/README.md
@@ -49,8 +49,8 @@ Implementing `GET /search` is **required**, `POST /search` is optional, but reco
 
 ## Link Relations
 
-While the STAC definition of Link does not require the `type` field,
-*STAC API - Item Search* requires all Links to have this field.
+The STAC definition of Link does not require the `type` field,
+but it is **STRONGLY RECOMMENDED** that this field exists.
 If the target of a Link's `type` is unknown, `type` SHOULD be set to `application/octet-stream` or `text/plain`.
 
 This conformance class also requires implementation of the link relations in the [STAC API - Core](../core) conformance class.

--- a/ogcapi-features/README.md
+++ b/ogcapi-features/README.md
@@ -100,8 +100,8 @@ by *STAC API - Core*, the
 
 These conformance classes also requires implementation of the link relations in the [STAC API - Core](../core) conformance class.
 
-While the STAC definition of Link does not require the `type` field, this is required by OAFeat,
-and is thereby required by the *STAC API - Features* conformance class.
+The STAC definition of Link does not require the `type` field,
+but it is **STRONGLY RECOMMENDED** that this field exists.
 If the target of a Link's `type` is unknown, `type` SHOULD be set to `application/octet-stream` or `text/plain`.
 
 ### Landing Page (/)


### PR DESCRIPTION
**Related Issue(s):** 

- https://github.com/radiantearth/stac-api-spec/issues/413

**Proposed Changes:**

1. Link `type` field is no longer required, after a clarification in the OAFeat spec about that as a (mistaken) requirement 

**PR Checklist:**

- [ ] This PR has **no** breaking changes.
- [X] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [X] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
