### PR TITLE
Fix bbox in README example

### DIFF
--- a/item-search/README.md
+++ b/item-search/README.md
@@ -97,7 +97,7 @@ GET /search?collections=landsat8,sentinel&bbox=-10.415,36.066,3.779,44.213&limit
 ```json
 {
     "collections": ["landsat8","sentinel"],
-    "bbox": [10.415,36.066,3.779,44.213],
+    "bbox": [-10.415,36.066,3.779,44.213],
     "limit": 200,
     "datetime": "2017-05-05T00:00:00Z"
 }


### PR DESCRIPTION
The bbox in the example has xmin > xmax.

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [x] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
