### PR TITLE
Added the missing `assets` property to Collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ None
 ### Changed
 
 - Field `type` is no longer required for all Link objects, but is instead strongly
+  recommended. This was added as a requirement in 1.0.0-rc.3 based on a mis-reading
+  of the OGC Features spec, and is now removed as a requirement.
 
 ## [v1.0.0-rc.3] - 2023-03-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,29 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Added the missing `assets` property to Collections
+
 ## [v1.0.0] - 2023-04-24
 
 None
 
 ## [v1.0.0-rc.4] - 2023-04-13
 
-## Changed
+### Changed
 
 - Field `type` is no longer required for all Link objects, but is instead strongly
-  recommended. This was added as a requirement in 1.0.0-rc.3 based on a mis-reading
-  of the OGC Features spec, and is now removed as a requirement.
 
 ## [v1.0.0-rc.3] - 2023-03-27
 
-## Changed
+### Changed
 
 - Browseable has been moved to an extension, now located at <https://github.com/stac-api-extensions/browseable>
 - Link relation `parent` is no longer a required link for Collections or Items
 - Field `type` is now required for all Link objects
 
-## Added
+### Added
 
 - Added authentication status code recommendations.
+
 - Added extension field to all OpenAPI specifications `x-conformance-classes` indicating the
   conformance classes they define.
 - STAC API - Item Search now requires a `root` link relation in the response from `/search`

--- a/core/commons.yaml
+++ b/core/commons.yaml
@@ -107,6 +107,8 @@ components:
           $ref: "#/components/schemas/extent"
         providers:
           $ref: "#/components/schemas/providers"
+        assets:
+          $ref: "#/components/schemas/assets"
         links:
           $ref: "#/components/schemas/links"
         summaries:


### PR DESCRIPTION
**Proposed Changes:**

1. Added the missing `assets` property to Collections

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [x] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
