### PR TITLE
Update examples.md to include 'last page' response example

### DIFF
--- a/item-search/examples.md
+++ b/item-search/examples.md
@@ -62,7 +62,9 @@ Response with `200 OK`:
 ```json
 {
     "type": "FeatureCollection",
-    "features": [],
+    "features": [
+       ...
+    ],
     "links": [
         {
             "rel": "first",

--- a/item-search/examples.md
+++ b/item-search/examples.md
@@ -50,6 +50,41 @@ Response with `200 OK`:
 
 Following the link `https://stac-api.example.com/search?page=2` will send the user to the next page of results.
 
+#### Simple GET based search showing the last page of results
+
+Request:
+```
+HTTP GET /search?bbox=-110,39.5,-105,40.5
+```
+
+Response with `200 OK`:
+
+```json
+{
+    "type": "FeatureCollection",
+    "features": [],
+    "links": [
+        {
+            "rel": "first",
+            "href": "https://stac-api.example.com/search?page=1",
+            "type": "application/geo+json"
+        },
+        {
+            "rel": "prev",
+            "href": "https://stac-api.example.com/search?page=7",
+            "type": "application/geo+json"
+        },
+        {
+            "rel": "root",
+            "href": "https://stac-api.example.com/",
+            "type": "application/json"
+        }
+    ]
+}
+```
+
+Notice the absence of a `next` link. This indicates to the client that this response is the last page of results for the submitted request.
+
 #### POST search with body and merge fields
 
 Request to `HTTP POST /search`:


### PR DESCRIPTION
added 'last page' response example

**Related Issue(s):** 

- #

**Proposed Changes:**

1. 
2. 

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [x] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
