### PR TITLE
Allow null geometry #430

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Allow the `geometry` property in Items to be set to `null` to align with STAC
 - Fix the schema for Collection summaries:
   - Allow JSON Schema
   - Update `min` and `max` to `minimum` and `maxmimum`

--- a/core/commons.yaml
+++ b/core/commons.yaml
@@ -586,7 +586,7 @@ components:
         bbox:
           $ref: "#/components/schemas/bbox"
         geometry:
-          $ref: "#/components/schemas/geometryGeoJSON"
+          $ref: "#/components/schemas/geometry"
         type:
           $ref: "#/components/schemas/itemType"
         links:
@@ -718,6 +718,13 @@ components:
             description: Purposes of the asset
             example:
               - thumbnail
+    geometry:
+      oneOf:
+        - $ref: "#/components/schemas/geometryGeoJSON"
+        - title: Unlocated Feature
+          nullable: true
+          enum:
+          - null
     geometryGeoJSON:
       oneOf:
         - $ref: "#/components/schemas/pointGeoJSON"
@@ -879,7 +886,7 @@ components:
           enum:
             - Feature
         geometry:
-          $ref: "#/components/schemas/geometryGeoJSON"
+          $ref: "#/components/schemas/geometry"
         properties:
           type: object
           nullable: true


### PR DESCRIPTION
**Related Issue(s):** 

- #430

**Proposed Changes:**

1. Allow null geometry to align with STAC and Features

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [x] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
