### PR TITLE
fix collections query param typo in OGC API features reference

### DIFF
--- a/ogcapi-features/README.md
+++ b/ogcapi-features/README.md
@@ -215,7 +215,7 @@ to `/collections/{collectionId}/items`. However, static catalogs and other parts
 It is recommended to have each OAFeat Collection correspond to a STAC Collection,
 and the `/collections/{collectionId}/items` endpoint can be used as a single collection search. Implementations may **optionally**
 provide support for the full superset of STAC API query parameters to the `/collections/{collectionId}/items` endpoint,
-where the collection ID in the path is equivalent to providing that single value in the `Collections* query parameter in
+where the collection ID in the path is equivalent to providing that single value in the `collections` query parameter in
 STAC API.
 
 Implementing OAFeat enables a wider range of clients to access the API's STAC Item objects, as it is a more widely implemented


### PR DESCRIPTION
**Related Issue(s):** 

- n/a

**Proposed Changes:**

1. Fix a Markdown typo.

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [x] This PR does not make any changes to the core spec in the `stac-spec` directory (these are included as a subtree and should be updated directly in [radiantearth/stac-spec](https://github.com/radiantearth/stac-spec))
- [x] I have added my changes to the [CHANGELOG](https://github.com/radiantearth/stac-api-spec/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
